### PR TITLE
Add release config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "monorepo-tools"]
 	path = monorepo-tools
 	url = git@github.com:district0x/monorepo-tools.git
-	branch = master
+	branch = improve-config-and-help

--- a/bb.edn
+++ b/bb.edn
@@ -12,8 +12,13 @@
                           :task (apply update-library-versions/-main *command-line-args*)}
 
          release {:doc "Try to shell out to clojure. Use: bb release VERSION LIBPATH" ; 20.10.9 shared/cljs-web3-next
+                  ; The escaping is needed to make Clojure interpret version (20.10.1) as string instead of number (and therefore failing)
                   :task (clojure (format "-X release/-main :version '\"%s\"' :library '%s'" (first *command-line-args*) (second *command-line-args*)))}
 
          mt-test {:doc "Run monorepo-tools tests"
                   :requires ([test-runner])
-                  :task (test-runner/-main *command-line-args*)}}}
+                  :task (test-runner/-main *command-line-args*)}
+
+         find-candidates {:doc "Finds all library candidates form folder for for monorepo migration. Outputs script to be used with `bb migrate`"
+                          :requires [find-migrate-candidates]
+                          :task (apply find-migrate-candidates/-main *command-line-args*)}}}

--- a/monorepo-config.edn
+++ b/monorepo-config.edn
@@ -1,0 +1,1 @@
+{:artefact-group "is.mad"}


### PR DESCRIPTION
With the newest `monorepo-tools` it's possible to detect the migratable libraries and auto-generate command-line calls to migrate them:

```
❯ bb find-candidates browser ../district-ui-*
Inspected paths:

| :nr |                                           :path | OK? |                                                         missing |
|-----+-------------------------------------------------+-----+-----------------------------------------------------------------|
|   1 |         ../district-ui-component-active-account |   ✓ |                                                                 |
|   2 | ../district-ui-component-active-account-balance |   ✓ |                                                                 |
|   3 |        ../district-ui-component-add-to-calendar |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|   4 |                   ../district-ui-component-form |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|   5 |                  ../district-ui-component-input |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|   6 |              ../district-ui-component-meta-tags |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|   7 |           ../district-ui-component-notification |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|   8 |              ../district-ui-component-tx-button |   ✓ |                                                                 |
|   9 |                 ../district-ui-conversion-rates |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|  10 |                          ../district-ui-graphql |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|  11 |                             ../district-ui-ipfs |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|  12 |                          ../district-ui-logging |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|  13 |                           ../district-ui-mobile |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|  14 |                     ../district-ui-notification |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|  15 |                              ../district-ui-now |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|  16 |                   ../district-ui-reagent-render |   ✓ |                                                                 |
|  17 |                           ../district-ui-router |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|  18 |          ../district-ui-router-google-analytics |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|  19 |                    ../district-ui-server-config |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|  20 |                  ../district-ui-service-workers |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|  21 |                  ../district-ui-smart-contracts |   ✓ |                                                                 |
|  22 |                             ../district-ui-web3 |   ✓ |                                                                 |
|  23 |            ../district-ui-web3-account-balances |   ✓ |                                                                 |
|  24 |                    ../district-ui-web3-accounts |   ✓ |                                                                 |
|  25 |                    ../district-ui-web3-balances |   ✓ |                                                                 |
|  26 |                       ../district-ui-web3-chain |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|  27 |                    ../district-ui-web3-sync-now |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|  28 |                          ../district-ui-web3-tx |   ✓ |                                                                 |
|  29 |                    ../district-ui-web3-tx-costs |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|  30 |                       ../district-ui-web3-tx-id |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|  31 |                      ../district-ui-web3-tx-log |   ✓ |                                                                 |
|  32 |                 ../district-ui-web3-tx-log-core |   ✓ |                                                                 |
|  33 |                     ../district-ui-window-focus |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |
|  34 |                      ../district-ui-window-size |     | ("shadow-cljs.edn" "deps.edn" "(lib_version.clj or build.clj)") |

Commands to run (for migrating to current folder `.`):

bb migrate ../district-ui-component-active-account . browser --no-create-branch
bb migrate ../district-ui-component-active-account-balance . browser --no-create-branch
bb migrate ../district-ui-component-tx-button . browser --no-create-branch
bb migrate ../district-ui-reagent-render . browser --no-create-branch
bb migrate ../district-ui-smart-contracts . browser --no-create-branch
bb migrate ../district-ui-web3 . browser --no-create-branch
bb migrate ../district-ui-web3-account-balances . browser --no-create-branch
bb migrate ../district-ui-web3-accounts . browser --no-create-branch
bb migrate ../district-ui-web3-balances . browser --no-create-branch
bb migrate ../district-ui-web3-tx . browser --no-create-branch
bb migrate ../district-ui-web3-tx-log . browser --no-create-branch
bb migrate ../district-ui-web3-tx-log-core . browser --no-create-branch
```