### PR TITLE
Release under is.d0x

### DIFF
--- a/browser/district-ui-bundle/deps.edn
+++ b/browser/district-ui-bundle/deps.edn
@@ -3,48 +3,54 @@
  {"central" {:url "https://repo1.maven.org/maven2/"},
   "clojars" {:url "https://clojars.org/repo"}},
  :deps
- {is.mad/district-ui-web3-sync-now {:mvn/version "LATEST"},
-  is.mad/district-ui-web3-tx-log {:mvn/version "LATEST"},
-  is.mad/district-ui-component-tx-button {:mvn/version "LATEST"},
-  is.mad/district-ui-web3-tx {:mvn/version "LATEST"},
-  is.mad/district-ui-web3-tx-id {:mvn/version "LATEST"},
-  is.mad/district-ui-web3-accounts {:mvn/version "LATEST"},
-  is.mad/district-ui-web3-balances {:mvn/version "LATEST"},
-  is.mad/district-ui-reagent-render {:mvn/version "LATEST"},
-  is.mad/district-ui-web3-chain {:mvn/version "LATEST"},
-  is.mad/district-ui-web3-account-balances {:mvn/version "LATEST"},
-  is.mad/district-ui-web3-tx-log-core {:mvn/version "LATEST"},
-  is.mad/district-ui-web3 {:mvn/version "LATEST"},
-  is.mad/district-ui-smart-contracts {:mvn/version "LATEST"},
-  is.mad/district-ui-component-active-account-balance
+ {is.d0x/district-ui-web3-tx-costs {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-tx-id {:mvn/version "LATEST"},
+  is.d0x/district-ui-reagent-render {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-account-balances {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-accounts {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-tx-log {:mvn/version "LATEST"},
+  is.d0x/district-ui-component-tx-button {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-chain {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-tx {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-tx-log-core {:mvn/version "LATEST"},
+  is.d0x/district-ui-smart-contracts {:mvn/version "LATEST"},
+  is.d0x/district-ui-component-active-account-balance
   {:mvn/version "LATEST"},
-  is.mad/district-ui-web3-tx-costs {:mvn/version "LATEST"}},
+  is.d0x/district-ui-web3-sync-now {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3 {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-balances {:mvn/version "LATEST"}},
  :aliases
  {:dev {:extra-deps {org.clojure/clojure {:mvn/version "1.11.1"}}},
   :local-deps
   {:override-deps
-   {is.mad/district-ui-web3-sync-now
-    {:local/root "../district-ui-web3-sync-now"},
-    is.mad/district-ui-web3-tx-log
-    {:local/root "../district-ui-web3-tx-log"},
-    is.mad/district-ui-component-tx-button
-    {:local/root "../district-ui-component-tx-button"},
-    is.mad/district-ui-web3-tx {:local/root "../district-ui-web3-tx"},
-    is.mad/district-ui-web3-tx-id
+   {is.d0x/district-ui-web3-tx-costs
+    {:local/root "../district-ui-web3-tx-costs"},
+    is.d0x/district-ui-web3-tx-id
     {:local/root "../district-ui-web3-tx-id"},
-    is.mad/district-ui-reagent-render
+    is.d0x/district-ui-reagent-render
     {:local/root "../district-ui-reagent-render"},
-    is.mad/district-ui-web3-chain
+    is.d0x/district-ui-web3-account-balances
+    {:local/root "../district-ui-web3-account-balances"},
+    is.d0x/district-ui-web3-accounts
+    {:local/root "../district-ui-web3-accounts"},
+    is.d0x/district-ui-web3-tx-log
+    {:local/root "../district-ui-web3-tx-log"},
+    is.d0x/district-ui-component-tx-button
+    {:local/root "../district-ui-component-tx-button"},
+    is.d0x/district-ui-web3-chain
     {:local/root "../district-ui-web3-chain"},
-    is.mad/district-ui-web3-tx-log-core
+    is.d0x/district-ui-web3-tx {:local/root "../district-ui-web3-tx"},
+    is.d0x/district-ui-web3-tx-log-core
     {:local/root "../district-ui-web3-tx-log-core"},
-    is.mad/district-ui-web3 {:local/root "../district-ui-web3"},
-    is.mad/district-ui-smart-contracts
+    is.d0x/district-ui-smart-contracts
     {:local/root "../district-ui-smart-contracts"},
-    is.mad/district-ui-component-active-account-balance
+    is.d0x/district-ui-component-active-account-balance
     {:local/root "../district-ui-component-active-account-balance"},
-    is.mad/district-ui-web3-tx-costs
-    {:local/root "../district-ui-web3-tx-costs"}}},
+    is.d0x/district-ui-web3-sync-now
+    {:local/root "../district-ui-web3-sync-now"},
+    is.d0x/district-ui-web3 {:local/root "../district-ui-web3"},
+    is.d0x/district-ui-web3-balances
+    {:local/root "../district-ui-web3-balances"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},
    :main-opts ["-m" "shadow.cljs.devtools.cli"]}}}

--- a/browser/district-ui-component-active-account-balance/deps.edn
+++ b/browser/district-ui-component-active-account-balance/deps.edn
@@ -7,7 +7,7 @@
   thheller/shadow-cljs {:mvn/version "2.19.8"},
   org.clojure/clojurescript {:mvn/version "1.11.60"},
   district0x/district-format {:mvn/version "1.0.6"},
-  is.mad/district-ui-web3-account-balances {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-account-balances {:mvn/version "LATEST"},
   re-frame/re-frame {:mvn/version "1.2.0"}},
  :install-deps true,
  :aliases
@@ -28,7 +28,7 @@
    {is.mad/district-ui-web3-account-balances
     {:local/root "../district-ui-web3-account-balances"}},
    :override-deps
-   {is.mad/district-ui-web3-account-balances
+   {is.d0x/district-ui-web3-account-balances
     {:local/root "../district-ui-web3-account-balances"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/browser/district-ui-component-tx-button/deps.edn
+++ b/browser/district-ui-component-tx-button/deps.edn
@@ -6,7 +6,7 @@
  {org.clojure/clojure {:mvn/version "1.11.1"},
   thheller/shadow-cljs {:mvn/version "2.19.8"},
   org.clojure/clojurescript {:mvn/version "1.11.60"},
-  is.mad/district-ui-web3-accounts {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-accounts {:mvn/version "LATEST"},
   re-frame/re-frame {:mvn/version "1.2.0"},
   toyokumo/semantic-ui-reagent {:mvn/version "0.2.0"},
   mount/mount {:mvn/version "0.1.16"}},
@@ -32,7 +32,7 @@
    :exec-fn deps-deploy.deps-deploy/deploy},
   :local-deps
   {:override-deps
-   {is.mad/district-ui-web3-accounts
+   {is.d0x/district-ui-web3-accounts
     {:local/root "../district-ui-web3-accounts"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/browser/district-ui-smart-contracts/deps.edn
+++ b/browser/district-ui-smart-contracts/deps.edn
@@ -14,9 +14,9 @@
   district0x/re-frame-spec-interceptors {:mvn/version "1.0.1"},
   day8.re-frame/forward-events-fx {:mvn/version "0.0.6"},
   mount/mount {:mvn/version "0.1.16"},
-  is.mad/district-ui-web3 {:mvn/version "LATEST"},
-  district0x/district-ui-logging {:mvn/version "1.1.0"},
-  is.mad/cljs-web3-next {:mvn/version "LATEST"}},
+  is.d0x/cljs-web3-next {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3 {:mvn/version "LATEST"},
+  district0x/district-ui-logging {:mvn/version "1.1.0"}},
  :aliases
  {:dev
   {:extra-deps
@@ -35,8 +35,8 @@
    :exec-fn deps-deploy.deps-deploy/deploy},
   :local-deps
   {:override-deps
-   {is.mad/district-ui-web3 {:local/root "../district-ui-web3"},
-    is.mad/cljs-web3-next
+   {is.d0x/district-ui-web3 {:local/root "../district-ui-web3"},
+    is.d0x/cljs-web3-next
     {:local/root "../../shared/cljs-web3-next"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/browser/district-ui-web3-account-balances/deps.edn
+++ b/browser/district-ui-web3-account-balances/deps.edn
@@ -4,15 +4,15 @@
   "clojars" {:url "https://clojars.org/repo"}},
  :deps
  {org.clojure/clojure {:mvn/version "1.11.1"},
-  is.mad/district-ui-web3-accounts {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-accounts {:mvn/version "LATEST"},
   thheller/shadow-cljs {:mvn/version "2.19.8"},
   org.clojure/clojurescript {:mvn/version "1.11.60"},
   re-frame/re-frame {:mvn/version "1.2.0"},
   district0x/re-frame-spec-interceptors {:mvn/version "1.0.1"},
   day8.re-frame/forward-events-fx {:mvn/version "0.0.6"},
   mount/mount {:mvn/version "0.1.16"},
-  is.mad/district-ui-web3-balances {:mvn/version "LATEST"},
-  district0x/district-format {:mvn/version "1.0.6"}},
+  district0x/district-format {:mvn/version "1.0.6"},
+  is.d0x/district-ui-web3-balances {:mvn/version "LATEST"}},
  :install-deps true,
  :aliases
  {:dev
@@ -34,9 +34,9 @@
    :exec-fn deps-deploy.deps-deploy/deploy},
   :local-deps
   {:override-deps
-   {is.mad/district-ui-web3-accounts
+   {is.d0x/district-ui-web3-accounts
     {:local/root "../district-ui-web3-accounts"},
-    is.mad/district-ui-web3-balances
+    is.d0x/district-ui-web3-balances
     {:local/root "../district-ui-web3-balances"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/browser/district-ui-web3-accounts/deps.edn
+++ b/browser/district-ui-web3-accounts/deps.edn
@@ -14,8 +14,8 @@
   district0x/re-frame-spec-interceptors {:mvn/version "1.0.1"},
   day8.re-frame/forward-events-fx {:mvn/version "0.0.6"},
   mount/mount {:mvn/version "0.1.16"},
-  is.mad/district-ui-web3 {:mvn/version "LATEST"},
-  is.mad/cljs-web3-next {:mvn/version "LATEST"}},
+  is.d0x/cljs-web3-next {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3 {:mvn/version "LATEST"}},
  :install-deps true,
  :aliases
  {:dev {:extra-deps {day8.re-frame/test {:mvn/version "0.1.5"}}},
@@ -29,8 +29,8 @@
    :exec-fn deps-deploy.deps-deploy/deploy},
   :local-deps
   {:override-deps
-   {is.mad/district-ui-web3 {:local/root "../district-ui-web3"},
-    is.mad/cljs-web3-next
+   {is.d0x/district-ui-web3 {:local/root "../district-ui-web3"},
+    is.d0x/cljs-web3-next
     {:local/root "../../shared/cljs-web3-next"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/browser/district-ui-web3-balances/deps.edn
+++ b/browser/district-ui-web3-balances/deps.edn
@@ -13,7 +13,7 @@
   {:mvn/version "1.0.1",
    :exclusions [re-frame/re-frame org.clojure/clojurescript]},
   mount/mount {:mvn/version "0.1.16"},
-  is.mad/district-ui-web3 {:mvn/version "LATEST"}},
+  is.d0x/district-ui-web3 {:mvn/version "LATEST"}},
  :install-deps true,
  :aliases
  {:dev
@@ -31,7 +31,7 @@
    :exec-fn deps-deploy.deps-deploy/deploy},
   :local-deps
   {:override-deps
-   {is.mad/district-ui-web3 {:local/root "../district-ui-web3"}}},
+   {is.d0x/district-ui-web3 {:local/root "../district-ui-web3"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},
    :main-opts ["-m" "shadow.cljs.devtools.cli"]}}}

--- a/browser/district-ui-web3-chain/deps.edn
+++ b/browser/district-ui-web3-chain/deps.edn
@@ -14,8 +14,8 @@
   district0x/re-frame-spec-interceptors {:mvn/version "1.0.1"},
   day8.re-frame/forward-events-fx {:mvn/version "0.0.6"},
   mount/mount {:mvn/version "0.1.16"},
-  is.mad/district-ui-web3 {:mvn/version "LATEST"},
-  is.mad/cljs-web3-next {:mvn/version "LATEST"}},
+  is.d0x/cljs-web3-next {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3 {:mvn/version "LATEST"}},
  :install-deps true,
  :aliases
  {:dev
@@ -32,8 +32,8 @@
    :exec-fn deps-deploy.deps-deploy/deploy},
   :local-deps
   {:override-deps
-   {is.mad/district-ui-web3 {:local/root "../district-ui-web3"},
-    is.mad/cljs-web3-next
+   {is.d0x/district-ui-web3 {:local/root "../district-ui-web3"},
+    is.d0x/cljs-web3-next
     {:local/root "../../shared/cljs-web3-next"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/browser/district-ui-web3-sync-now/deps.edn
+++ b/browser/district-ui-web3-sync-now/deps.edn
@@ -13,9 +13,9 @@
   io.github.district0x/district-web3-utils
   {:mvn/version "1.1.0-SNAPSHOT"},
   mount/mount {:mvn/version "0.1.16"},
-  is.mad/district-ui-web3 {:mvn/version "LATEST"},
-  district0x/district-ui-logging {:mvn/version "1.1.0"},
-  is.mad/cljs-web3-next {:mvn/version "LATEST"}},
+  is.d0x/cljs-web3-next {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3 {:mvn/version "LATEST"},
+  district0x/district-ui-logging {:mvn/version "1.1.0"}},
  :install-deps true,
  :aliases
  {:dev
@@ -32,8 +32,8 @@
    :exec-fn deps-deploy.deps-deploy/deploy},
   :local-deps
   {:override-deps
-   {is.mad/district-ui-web3 {:local/root "../district-ui-web3"},
-    is.mad/cljs-web3-next
+   {is.d0x/district-ui-web3 {:local/root "../district-ui-web3"},
+    is.d0x/cljs-web3-next
     {:local/root "../../shared/cljs-web3-next"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/browser/district-ui-web3-tx-costs/deps.edn
+++ b/browser/district-ui-web3-tx-costs/deps.edn
@@ -4,14 +4,14 @@
   "clojars" {:url "https://clojars.org/repo"}},
  :deps
  {org.clojure/clojure {:mvn/version "1.11.1"},
-  is.mad/district-ui-web3-tx {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-tx {:mvn/version "LATEST"},
   org.clojure/clojurescript {:mvn/version "1.11.60"},
   district0x/district-ui-conversion-rates {:mvn/version "1.0.1"},
   re-frame/re-frame {:mvn/version "1.2.0"},
   day8.re-frame/forward-events-fx {:mvn/version "0.0.6"},
   district0x/bignumber {:mvn/version "1.0.3"},
   mount/mount {:mvn/version "0.1.16"},
-  is.mad/cljs-web3-next {:mvn/version "LATEST"}},
+  is.d0x/cljs-web3-next {:mvn/version "LATEST"}},
  :install-deps true,
  :aliases
  {:dev
@@ -29,8 +29,8 @@
    :exec-fn deps-deploy.deps-deploy/deploy},
   :local-deps
   {:override-deps
-   {is.mad/district-ui-web3-tx {:local/root "../district-ui-web3-tx"},
-    is.mad/cljs-web3-next
+   {is.d0x/district-ui-web3-tx {:local/root "../district-ui-web3-tx"},
+    is.d0x/cljs-web3-next
     {:local/root "../../shared/cljs-web3-next"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/browser/district-ui-web3-tx-id/deps.edn
+++ b/browser/district-ui-web3-tx-id/deps.edn
@@ -4,17 +4,17 @@
   "clojars" {:url "https://clojars.org/repo"}},
  :deps
  {org.clojure/clojure {:mvn/version "1.11.1"},
-  is.mad/district-ui-web3-accounts {:mvn/version "LATEST"},
-  is.mad/district-ui-web3-tx {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-accounts {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-tx {:mvn/version "LATEST"},
   thheller/shadow-cljs {:mvn/version "2.18.0"},
   org.clojure/clojurescript {:mvn/version "1.11.60"},
   re-frame/re-frame {:mvn/version "1.2.0"},
   district0x/re-frame-spec-interceptors {:mvn/version "1.0.1"},
   day8.re-frame/forward-events-fx {:mvn/version "0.0.6"},
   mount/mount {:mvn/version "0.1.16"},
+  is.d0x/cljs-web3-next {:mvn/version "LATEST"},
   akiroz.re-frame/storage {:mvn/version "0.1.4"},
-  medley/medley {:mvn/version "1.4.0"},
-  is.mad/cljs-web3-next {:mvn/version "LATEST"}},
+  medley/medley {:mvn/version "1.4.0"}},
  :install-deps true,
  :aliases
  {:dev
@@ -34,10 +34,10 @@
    :exec-fn deps-deploy.deps-deploy/deploy},
   :local-deps
   {:override-deps
-   {is.mad/district-ui-web3-accounts
+   {is.d0x/district-ui-web3-accounts
     {:local/root "../district-ui-web3-accounts"},
-    is.mad/district-ui-web3-tx {:local/root "../district-ui-web3-tx"},
-    is.mad/cljs-web3-next
+    is.d0x/district-ui-web3-tx {:local/root "../district-ui-web3-tx"},
+    is.d0x/cljs-web3-next
     {:local/root "../../shared/cljs-web3-next"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/browser/district-ui-web3-tx-log-core/deps.edn
+++ b/browser/district-ui-web3-tx-log-core/deps.edn
@@ -9,7 +9,7 @@
   re-frame/re-frame {:mvn/version "1.2.0"},
   mount/mount {:mvn/version "0.1.16"},
   day8.re-frame/forward-events-fx {:mvn/version "0.0.6"},
-  is.mad/district-ui-web3-tx {:mvn/version "LATEST"}},
+  is.d0x/district-ui-web3-tx {:mvn/version "LATEST"}},
  :install-deps true,
  :aliases
  {:dev
@@ -28,7 +28,7 @@
    :exec-fn deps-deploy.deps-deploy/deploy},
   :local-deps
   {:override-deps
-   {is.mad/district-ui-web3-tx
+   {is.d0x/district-ui-web3-tx
     {:local/root "../district-ui-web3-tx"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/browser/district-ui-web3-tx-log/deps.edn
+++ b/browser/district-ui-web3-tx-log/deps.edn
@@ -4,18 +4,18 @@
   "clojars" {:url "https://clojars.org/repo"}},
  :deps
  {org.clojure/clojure {:mvn/version "1.11.1"},
-  is.mad/district-ui-web3-accounts {:mvn/version "LATEST"},
-  is.mad/district-ui-web3-tx {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-tx-costs {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-accounts {:mvn/version "LATEST"},
+  is.d0x/district-ui-web3-tx {:mvn/version "LATEST"},
   thheller/shadow-cljs {:mvn/version "2.19.8"},
   org.clojure/clojurescript {:mvn/version "1.11.60"},
   toyokumo/semantic-ui-reagent {:mvn/version "0.2.0"},
   district0x/district-ui-router {:mvn/version "1.0.8"},
   re-frame/re-frame {:mvn/version "1.2.0"},
+  is.d0x/district-ui-web3-tx-log-core {:mvn/version "LATEST"},
   io.github.district0x/district-web3-utils
   {:mvn/version "1.1.0-SNAPSHOT"},
-  is.mad/district-ui-web3-tx-log-core {:mvn/version "LATEST"},
   mount/mount {:mvn/version "0.1.16"},
-  is.mad/district-ui-web3-tx-costs {:mvn/version "LATEST"},
   akiroz.re-frame/storage {:mvn/version "0.1.4"}},
  :install-deps true,
  :aliases
@@ -37,12 +37,12 @@
    :exec-fn deps-deploy.deps-deploy/deploy},
   :local-deps
   {:override-deps
-   {is.mad/district-ui-web3-accounts
+   {is.d0x/district-ui-web3-accounts
     {:local/root "../district-ui-web3-accounts"},
-    is.mad/district-ui-web3-tx {:local/root "../district-ui-web3-tx"},
-    is.mad/district-ui-web3-tx-log-core
+    is.d0x/district-ui-web3-tx {:local/root "../district-ui-web3-tx"},
+    is.d0x/district-ui-web3-tx-log-core
     {:local/root "../district-ui-web3-tx-log-core"},
-    is.mad/district-ui-web3-tx-costs
+    is.d0x/district-ui-web3-tx-costs
     {:local/root "../district-ui-web3-tx-costs"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/browser/district-ui-web3-tx/deps.edn
+++ b/browser/district-ui-web3-tx/deps.edn
@@ -19,10 +19,10 @@
   day8.re-frame/forward-events-fx {:mvn/version "0.0.6"},
   district0x/bignumber {:mvn/version "1.0.3"},
   mount/mount {:mvn/version "0.1.16"},
-  is.mad/district-ui-web3 {:mvn/version "LATEST"},
+  is.d0x/cljs-web3-next {:mvn/version "LATEST"},
   camel-snake-kebab/camel-snake-kebab {:mvn/version "0.4.1"},
   akiroz.re-frame/storage {:mvn/version "0.1.4"},
-  is.mad/cljs-web3-next {:mvn/version "LATEST"}},
+  is.d0x/district-ui-web3 {:mvn/version "LATEST"}},
  :install-deps true,
  :aliases
  {:dev
@@ -42,8 +42,8 @@
    :exec-fn deps-deploy.deps-deploy/deploy},
   :local-deps
   {:override-deps
-   {is.mad/district-ui-web3 {:local/root "../district-ui-web3"},
-    is.mad/cljs-web3-next
+   {is.d0x/district-ui-web3 {:local/root "../district-ui-web3"},
+    is.d0x/cljs-web3-next
     {:local/root "../../shared/cljs-web3-next"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/browser/district-ui-web3/deps.edn
+++ b/browser/district-ui-web3/deps.edn
@@ -5,7 +5,7 @@
  :deps
  {org.clojure/clojure {:mvn/version "1.11.1"},
   thheller/shadow-cljs {:mvn/version "2.19.3"},
-  is.mad/cljs-web3-next {:mvn/version "LATEST"},
+  is.d0x/cljs-web3-next {:mvn/version "LATEST"},
   mount/mount {:mvn/version "0.1.16"},
   day8.re-frame/test {:mvn/version "0.1.5"}},
  :install-deps true,
@@ -20,7 +20,7 @@
    :exec-fn deps-deploy.deps-deploy/deploy},
   :local-deps
   {:override-deps
-   {is.mad/cljs-web3-next
+   {is.d0x/cljs-web3-next
     {:local/root "../../shared/cljs-web3-next"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/monorepo-config.edn
+++ b/monorepo-config.edn
@@ -1,4 +1,4 @@
 {:tools-root "./monorepo-tools"
- :artefact-group "is.mad"
+ :artefact-group "is.d0x"
  :bundle-prefix "-district"
  :groups ["browser" "server" "shared"]}

--- a/server/district-server-bundle/deps.edn
+++ b/server/district-server-bundle/deps.edn
@@ -3,24 +3,24 @@
  {"central" {:url "https://repo1.maven.org/maven2/"},
   "clojars" {:url "https://clojars.org/repo"}},
  :deps
- {is.mad/district-server-db {:mvn/version "LATEST"},
-  is.mad/district-server-smart-contracts {:mvn/version "LATEST"},
-  is.mad/district-server-web3 {:mvn/version "LATEST"},
-  is.mad/district-server-web3-events {:mvn/version "LATEST"},
-  is.mad/district-server-web3-watcher {:mvn/version "LATEST"}},
+ {is.d0x/district-server-db {:mvn/version "LATEST"},
+  is.d0x/district-server-smart-contracts {:mvn/version "LATEST"},
+  is.d0x/district-server-web3 {:mvn/version "LATEST"},
+  is.d0x/district-server-web3-events {:mvn/version "LATEST"},
+  is.d0x/district-server-web3-watcher {:mvn/version "LATEST"}},
  :aliases
- {:test {:extra-paths ["test"]}
+ {:test {:extra-paths ["test"]},
   :dev {:extra-deps {org.clojure/clojure {:mvn/version "1.11.1"}}},
   :local-deps
   {:override-deps
-   {is.mad/district-server-db {:local/root "../district-server-db"},
-    is.mad/district-server-smart-contracts
+   {is.d0x/district-server-db {:local/root "../district-server-db"},
+    is.d0x/district-server-smart-contracts
     {:local/root "../district-server-smart-contracts"},
-    is.mad/district-server-web3
+    is.d0x/district-server-web3
     {:local/root "../district-server-web3"},
-    is.mad/district-server-web3-events
+    is.d0x/district-server-web3-events
     {:local/root "../district-server-web3-events"},
-    is.mad/district-server-web3-watcher
+    is.d0x/district-server-web3-watcher
     {:local/root "../district-server-web3-watcher"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/server/district-server-db/deps.edn
+++ b/server/district-server-db/deps.edn
@@ -12,7 +12,7 @@
   mount/mount {:mvn/version "0.1.16"}},
  :install-deps true,
  :aliases
- {:test {:extra-paths ["test"]}
+ {:test {:extra-paths ["test"]},
   :dev
   {:extra-deps
    {com.cemerick/piggieback {:mvn/version "0.2.2"},

--- a/server/district-server-smart-contracts/deps.edn
+++ b/server/district-server-smart-contracts/deps.edn
@@ -6,13 +6,13 @@
  {org.clojure/clojure {:mvn/version "1.11.1"},
   thheller/shadow-cljs {:mvn/version "2.19.8"},
   org.clojure/clojurescript {:mvn/version "1.11.60"},
-  is.mad/cljs-web3-next {:mvn/version "LATEST"},
+  is.d0x/cljs-web3-next {:mvn/version "LATEST"},
   district0x/district-server-config {:mvn/version "1.0.1"},
-  is.mad/district-server-web3 {:mvn/version "LATEST"},
+  is.d0x/district-server-web3 {:mvn/version "LATEST"},
   mount/mount {:mvn/version "0.1.16"}},
  :install-deps true,
  :aliases
- {:test {:extra-paths ["test"]}
+ {:test {:extra-paths ["test"]},
   :dev
   {:extra-deps
    {com.cemerick/piggieback {:mvn/version "0.2.2"},
@@ -28,8 +28,8 @@
    :exec-fn deps-deploy.deps-deploy/deploy},
   :local-deps
   {:override-deps
-   {is.mad/cljs-web3-next {:local/root "../../shared/cljs-web3-next"},
-    is.mad/district-server-web3
+   {is.d0x/cljs-web3-next {:local/root "../../shared/cljs-web3-next"},
+    is.d0x/district-server-web3
     {:local/root "../district-server-web3"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/server/district-server-web3-events/deps.edn
+++ b/server/district-server-web3-events/deps.edn
@@ -3,17 +3,17 @@
  {"central" {:url "https://repo1.maven.org/maven2/"},
   "clojars" {:url "https://clojars.org/repo"}},
  :deps
- {district0x/district-server-config {:mvn/version "1.0.1"},
+ {is.d0x/district-server-web3 {:mvn/version "LATEST"},
+  district0x/district-server-config {:mvn/version "1.0.1"},
   org.clojure/clojurescript {:mvn/version "1.11.60"},
-  is.mad/district-server-web3 {:mvn/version "LATEST"},
   district0x/async-helpers {:mvn/version "0.1.3"},
+  is.d0x/district-server-smart-contracts {:mvn/version "LATEST"},
   com.taoensso/timbre {:mvn/version "4.10.0"},
-  is.mad/district-server-smart-contracts {:mvn/version "LATEST"},
   mount/mount {:mvn/version "0.1.16"},
-  medley/medley {:mvn/version "1.4.0"},
-  is.mad/cljs-web3-next {:mvn/version "LATEST"}},
+  is.d0x/cljs-web3-next {:mvn/version "LATEST"},
+  medley/medley {:mvn/version "1.4.0"}},
  :aliases
- {:test {:extra-paths ["test"]}
+ {:test {:extra-paths ["test"]},
   :dev {:extra-deps {org.clojure/clojure {:mvn/version "1.11.1"}}},
   :build
   {:deps
@@ -29,11 +29,11 @@
     "target/district-server-web3-events-1.2.0-SNAPSHOT.jar"}},
   :local-deps
   {:override-deps
-   {is.mad/district-server-web3
+   {is.d0x/district-server-web3
     {:local/root "../district-server-web3"},
-    is.mad/district-server-smart-contracts
+    is.d0x/district-server-smart-contracts
     {:local/root "../district-server-smart-contracts"},
-    is.mad/cljs-web3-next
+    is.d0x/cljs-web3-next
     {:local/root "../../shared/cljs-web3-next"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/server/district-server-web3-watcher/deps.edn
+++ b/server/district-server-web3-watcher/deps.edn
@@ -6,12 +6,12 @@
  {org.clojure/clojure {:mvn/version "1.11.1"},
   thheller/shadow-cljs {:mvn/version "2.19.8"},
   org.clojure/clojurescript {:mvn/version "1.11.60"},
-  is.mad/district-server-web3 {:mvn/version "LATEST"},
-  is.mad/cljs-web3-next {:mvn/version "LATEST"},
+  is.d0x/district-server-web3 {:mvn/version "LATEST"},
+  is.d0x/cljs-web3-next {:mvn/version "LATEST"},
   mount/mount {:mvn/version "0.1.16"}},
  :install-deps true,
  :aliases
- {:test {:extra-paths ["test"]}
+ {:test {:extra-paths ["test"]},
   :dev
   {:extra-deps
    {com.cemerick/piggieback {:mvn/version "0.2.2"},
@@ -27,9 +27,9 @@
    :exec-fn deps-deploy.deps-deploy/deploy},
   :local-deps
   {:override-deps
-   {is.mad/district-server-web3
+   {is.d0x/district-server-web3
     {:local/root "../district-server-web3"},
-    is.mad/cljs-web3-next
+    is.d0x/cljs-web3-next
     {:local/root "../../shared/cljs-web3-next"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/server/district-server-web3/deps.edn
+++ b/server/district-server-web3/deps.edn
@@ -3,14 +3,14 @@
  {"central" {:url "https://repo1.maven.org/maven2/"},
   "clojars" {:url "https://clojars.org/repo"}},
  :deps
- {is.mad/cljs-web3-next {:mvn/version "LATEST"},
+ {is.d0x/cljs-web3-next {:mvn/version "LATEST"},
   com.taoensso/timbre {:mvn/version "4.10.0"},
   district0x/async-helpers {:mvn/version "0.1.3"},
   district0x/district-server-config {:mvn/version "1.0.1"},
   mount/mount {:mvn/version "0.1.16"},
   org.clojure/clojurescript {:mvn/version "1.11.60"}},
  :aliases
- {:test {:extra-paths ["test"]}
+ {:test {:extra-paths ["test"]},
   :dev {:extra-deps {org.clojure/clojure {:mvn/version "1.11.1"}}},
   :build
   {:deps
@@ -25,7 +25,7 @@
     :artifact "target/district-server-web3-1.3.0-SNAPSHOT.jar"}},
   :local-deps
   {:override-deps
-   {is.mad/cljs-web3-next
+   {is.d0x/cljs-web3-next
     {:local/root "../../shared/cljs-web3-next"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},

--- a/shared/district-shared-bundle/deps.edn
+++ b/shared/district-shared-bundle/deps.edn
@@ -2,12 +2,12 @@
  :mvn/repos
  {"central" {:url "https://repo1.maven.org/maven2/"},
   "clojars" {:url "https://clojars.org/repo"}},
- :deps {is.mad/cljs-web3-next {:mvn/version "LATEST"}},
+ :deps {is.d0x/cljs-web3-next {:mvn/version "LATEST"}},
  :aliases
  {:dev {:extra-deps {org.clojure/clojure {:mvn/version "1.11.1"}}},
   :local-deps
   {:override-deps
-   {is.mad/cljs-web3-next {:local/root "../cljs-web3-next"}}},
+   {is.d0x/cljs-web3-next {:local/root "../cljs-web3-next"}}},
   :shadow-cljs
   {:extra-deps {thheller/shadow-cljs {:mvn/version "2.19.8"}},
    :main-opts ["-m" "shadow.cljs.devtools.cli"]}}}

--- a/version-tracking.edn
+++ b/version-tracking.edn
@@ -1,4 +1,33 @@
-[{:created-at "2022-12-12T09:12:00.159372",
+[{:created-at "2022-12-12T10:20:21.160478",
+  :version "22.12.12-SNAPSHOT",
+  :description "First release under is.d0x",
+  :libs
+  ["server/district-server-smart-contracts"
+   "server/district-server-web3-watcher"
+   "server/district-server-db"
+   "server/district-server-web3-events"
+   "server/district-server-bundle"
+   "server/district-server-web3"
+   "browser/district-ui-web3-tx-log"
+   "browser/district-ui-web3-chain"
+   "browser/district-ui-web3-balances"
+   "browser/district-ui-web3-tx-log-core"
+   "browser/district-ui-bundle"
+   "browser/district-ui-web3-account-balances"
+   "browser/district-ui-web3-sync-now"
+   "browser/district-ui-web3"
+   "browser/district-ui-web3-tx"
+   "browser/district-ui-component-active-account-balance"
+   "browser/district-ui-web3-tx-costs"
+   "browser/district-ui-reagent-render"
+   "browser/district-ui-web3-accounts"
+   "browser/district-ui-component-tx-button"
+   "browser/district-ui-smart-contracts"
+   "browser/district-ui-web3-tx-id"
+   "shared/district-shared-bundle"
+   "shared/cljs-web3-next"],
+  :updated-at "2022-12-12T10:20:38.959286"}
+ {:created-at "2022-12-12T09:12:00.159372",
   :version "22.12.12-SNAPSHOT",
   :description "Relasing bundles and libraries in order",
   :libs


### PR DESCRIPTION
The build failed because the libraries were switched to `is.d0x` and during build tools.deps (via Maven) tries to get the dependencies but there are none yet published under `is.d0x` (they will after this pull request gets merged).

So to solve it, I released temporarily versions from all the libraries (manually) with version `0.0.1` to Clojars under `is.d0x`.

When the actual release is being done, the libraries get published in order so that the ones who depend on earlier ones, get published later (only after their dependents have been released). That way the `LATEST` version refers to the version published during that particular release.

```
❯ cat release-all.sh
bb release 0.0.1 server/district-server-db
bb release 0.0.1 server/district-server-web3
bb release 0.0.1 server/district-server-web3-watcher
bb release 0.0.1 browser/district-ui-web3
bb release 0.0.1 browser/district-ui-web3-chain
bb release 0.0.1 browser/district-ui-web3-accounts
bb release 0.0.1 browser/district-ui-component-tx-button
bb release 0.0.1 browser/district-ui-smart-contracts
bb release 0.0.1 browser/district-ui-web3-sync-now
bb release 0.0.1 shared/district-shared-bundle
bb release 0.0.1 browser/district-ui-web3-tx
bb release 0.0.1 browser/district-ui-web3-tx-log-core
bb release 0.0.1 browser/district-ui-web3-tx-costs
bb release 0.0.1 browser/district-ui-web3-tx-log
bb release 0.0.1 browser/district-ui-web3-balances
bb release 0.0.1 server/district-server-smart-contracts
bb release 0.0.1 server/district-server-web3-events
bb release 0.0.1 server/district-server-bundle
bb release 0.0.1 browser/district-ui-web3-account-balances
bb release 0.0.1 browser/district-ui-component-active-account-balance
bb release 0.0.1 browser/district-ui-reagent-render
bb release 0.0.1 browser/district-ui-web3-tx-id
bb release 0.0.1 browser/district-ui-bundle
```

Later I archived the forementioned libraries with the following babashka script:
```clojure
#!/usr/bin/env bb
(ns archive-libraries
  (:require [babashka.curl :as curl]
            [cheshire.core :as json]))

; curl \
;   -X PATCH \
;   -H "Accept: application/vnd.github+json" \
;   -H "Authorization: Bearer ...your token..." \
;   https://api.github.com/repos/madis/jetty \
;   -d '{"description":"⚠️ This code now resides at d0x monorepo","homepage":"https://github.com/district0x/d0x-libs","archived":true}'


(def libs-to-archive
  ["district-ui-component-active-account-balance"
   "district-ui-component-tx-button"
   "district-ui-reagent-render"
   "district-ui-smart-contracts"
   "district-ui-web3"
   "district-ui-web3-account-balances"
   "district-ui-web3-accounts"
   "district-ui-web3-balances"
   "district-ui-web3-chain"
   "district-ui-web3-sync-now"
   "district-ui-web3-tx"
   "district-ui-web3-tx-costs"
   "district-ui-web3-tx-id"
   "district-ui-web3-tx-log"
   "district-ui-web3-tx-log-core"
   "district-server-web3-watcher"
   "district-server-db"
   "district-server-smart-contracts"
   "district-server-web3"
   "district-server-web3-events"
   "cljs-web3-next"])

(defn archive [lib-name]
  (let [url (str "https://api.github.com/repos/district0x/" lib-name)
        headers {"Accept" "application/vnd.github+json"
                 "Authorization" "Bearer ...your token..."}
        body {"description" "⚠️ This code now resides at d0x monorepo"
              "homepage" "https://github.com/district0x/d0x-libs"
              "archived" true}]
    (println "RESPONSE: " (curl/patch url {:headers headers :body (json/generate-string body)}))))

(doall (map archive libs-to-archive))
```