### PR TITLE
Eth personal

### DIFF
--- a/browser/district-ui-web3/src/district/ui/web3/effects.cljs
+++ b/browser/district-ui-web3/src/district/ui/web3/effects.cljs
@@ -6,9 +6,9 @@
 
 (defn authorize []
   (try
-    (let [eth-send (aget js/window "ethereum" "send")]
+    (let [eth-send (aget js/window "ethereum" "request")]
      (if eth-send
-       (eth-send "eth_requestAccounts")
+       (eth-send #js {:method "eth_requestAccounts"})
        (js/Promise.reject "No ethereum send fn")))
     (catch js/Error e
       (js/Promise.reject (str "Error when calling eth_requestAccounts" e)))))

--- a/browser/district-ui-web3/src/district/ui/web3/ethereum_provider.cljs
+++ b/browser/district-ui-web3/src/district/ui/web3/ethereum_provider.cljs
@@ -15,9 +15,12 @@
 (defn supports-ethereum-provider?
   "Determines whether the browser has the window.ethereum object. All
   browsers are encouraged to implement this object with the method
-  `.send` to invoke an authorization dialog as defined by EIP-1102."
+  `.send` to invoke an authorization dialog as defined by EIP-1102.
+  Note this is no longer enforced, as shown in EIP-1193.
+  having window.ethereum is only a convention, not a standard,
+  and may not be the case for some providers"
   []
-  (some-> js/window (aget "ethereum") (aget "send")))
+  (some-> js/window (aget "ethereum") (aget "request")))
 
 
 (defn full-provider

--- a/shared/cljs-web3-next/src/cljs_web3_next/personal.cljs
+++ b/shared/cljs-web3-next/src/cljs_web3_next/personal.cljs
@@ -12,7 +12,7 @@
   Parameter:
   web3 - web3 instance"
   [web3]
-  (oget web3 "personal"))
+  (oget web3 "eth" "personal"))
 
 
 (def list-accounts
@@ -148,7 +148,6 @@
   String   - Data to sign. If String it will be converted using
              web3.utils.utf8ToHex.
   String   - Address to sign data with.
-  String   - The password of the account to sign data with.
   Function - (optional) Optional callback, returns an error object as first
                         parameter and the result as second.
 

--- a/shared/cljs-web3-next/test/tests/web3_tests.cljs
+++ b/shared/cljs-web3-next/test/tests/web3_tests.cljs
@@ -139,18 +139,12 @@
               block (js->clj (<! (web3-eth/get-block web3 block-number false)) :keywordize-keys true)]
           (web3-evm/snapshot! web3
             (fn [_err res]
-              (println "SNAPSHOT err" _err)
-              (println "SNAPSHOT res" res)
               (let [snapshot-id res]
                 (web3-evm/increase-time! web3 [3600]
                   (fn [_err res]
-                    (println "INCREASE TIME err" _err)
-                    (println "INCREASE TIME res" res)
                     (is (>= res 3600))
                     (web3-evm/mine-block! web3
                       (fn [_err _res]
-                        (println "MINE BLOCK err" _err)
-                        (println "MINE BLOCK res" _res)
                         (go
                           (let [new-block-number (<! (web3-eth/get-block-number web3))
                                 new-block (js->clj (<! (web3-eth/get-block web3 new-block-number false)) :keywordize-keys true)]
@@ -158,8 +152,6 @@
                             (is (<= (+ 3600 (:timestamp block)) (:timestamp new-block)))
                             (web3-evm/revert! web3 [snapshot-id]
                               (fn [_err _res]
-                                (println "REVERT err" _err)
-                                (println "REVERT res" _res)
                                 (go
                                   (let [new-block-number (<! (web3-eth/get-block-number web3))
                                        new-block (js->clj (<! (web3-eth/get-block web3 new-block-number false)) :keywordize-keys true)]

--- a/shared/cljs-web3-next/test/tests/web3_tests.cljs
+++ b/shared/cljs-web3-next/test/tests/web3_tests.cljs
@@ -139,12 +139,18 @@
               block (js->clj (<! (web3-eth/get-block web3 block-number false)) :keywordize-keys true)]
           (web3-evm/snapshot! web3
             (fn [_err res]
+              (print "SNAPSHOT err" _err)
+              (print "SNAPSHOT res" res)
               (let [snapshot-id res]
                 (web3-evm/increase-time! web3 [3600]
                   (fn [_err res]
+                    (print "INCREASE TIME err" _err)
+                    (print "INCREASE TIME res" res)
                     (is (>= res 3600))
                     (web3-evm/mine-block! web3
                       (fn [_err _res]
+                        (print "MINE BLOCK err" _err)
+                        (print "MINE BLOCK res" _res)
                         (go
                           (let [new-block-number (<! (web3-eth/get-block-number web3))
                                 new-block (js->clj (<! (web3-eth/get-block web3 new-block-number false)) :keywordize-keys true)]
@@ -152,6 +158,8 @@
                             (is (<= (+ 3600 (:timestamp block)) (:timestamp new-block)))
                             (web3-evm/revert! web3 [snapshot-id]
                               (fn [_err _res]
+                                (print "REVERT err" _err)
+                                (print "REVERT res" _res)
                                 (go
                                   (let [new-block-number (<! (web3-eth/get-block-number web3))
                                        new-block (js->clj (<! (web3-eth/get-block web3 new-block-number false)) :keywordize-keys true)]

--- a/shared/cljs-web3-next/test/tests/web3_tests.cljs
+++ b/shared/cljs-web3-next/test/tests/web3_tests.cljs
@@ -139,18 +139,18 @@
               block (js->clj (<! (web3-eth/get-block web3 block-number false)) :keywordize-keys true)]
           (web3-evm/snapshot! web3
             (fn [_err res]
-              (print "SNAPSHOT err" _err)
-              (print "SNAPSHOT res" res)
+              (println "SNAPSHOT err" _err)
+              (println "SNAPSHOT res" res)
               (let [snapshot-id res]
                 (web3-evm/increase-time! web3 [3600]
                   (fn [_err res]
-                    (print "INCREASE TIME err" _err)
-                    (print "INCREASE TIME res" res)
+                    (println "INCREASE TIME err" _err)
+                    (println "INCREASE TIME res" res)
                     (is (>= res 3600))
                     (web3-evm/mine-block! web3
                       (fn [_err _res]
-                        (print "MINE BLOCK err" _err)
-                        (print "MINE BLOCK res" _res)
+                        (println "MINE BLOCK err" _err)
+                        (println "MINE BLOCK res" _res)
                         (go
                           (let [new-block-number (<! (web3-eth/get-block-number web3))
                                 new-block (js->clj (<! (web3-eth/get-block web3 new-block-number false)) :keywordize-keys true)]
@@ -158,8 +158,8 @@
                             (is (<= (+ 3600 (:timestamp block)) (:timestamp new-block)))
                             (web3-evm/revert! web3 [snapshot-id]
                               (fn [_err _res]
-                                (print "REVERT err" _err)
-                                (print "REVERT res" _res)
+                                (println "REVERT err" _err)
+                                (println "REVERT res" _res)
                                 (go
                                   (let [new-block-number (<! (web3-eth/get-block-number web3))
                                        new-block (js->clj (<! (web3-eth/get-block web3 new-block-number false)) :keywordize-keys true)]

--- a/version-tracking.edn
+++ b/version-tracking.edn
@@ -1,7 +1,17 @@
-[{:created-at "2023-02-09T06:54:29.820472",
+[{:created-at "2023-03-01T15:42:46.624815",
+  :version "23.3.1",
+  :description "Minor fixes to cljs-web3-next",
+  :libs ["shared/cljs-web3-next",
+         "browser/district-ui-web3"],
+  :updated-at "2023-03-01T15:42:46.625332"}
+ {:created-at "2023-02-09T06:54:29.820472",
   :version "23.2.9",
   :description "Import 2 more libraries...",
-  :libs ["shared/district-sendgrid" "browser/district-ui-router" "shared/district-shared-bundle" "browser/district-ui-bundle"],
+  :libs
+  ["shared/district-sendgrid"
+   "browser/district-ui-router"
+   "shared/district-shared-bundle"
+   "browser/district-ui-bundle"],
   :updated-at "2023-02-09T06:54:50.63636"}
  {:created-at "2023-01-20T13:26:40.105215",
   :version "23.1.26",


### PR DESCRIPTION
The web3 "personal" package changed its location within the lib, but it was not reflected in cljs-web3-next. This PR changes from web3.personal to web3.eth.personal.

In addition to that, this PR avoids using window.ethereum.**send** to check if there is an ethereum provider in the browser or to authorize it because this has been deprecated (a deprecation warning is shown in the console). Instead, it uses window.ethereum.**request** which replaces it.

See [EIP-1193](https://eips.ethereum.org/EIPS/eip-1193)