### PR TITLE
Allow SQL format options

### DIFF
--- a/server/district-server-db/src/district/server/db.cljs
+++ b/server/district-server-db/src/district/server/db.cljs
@@ -40,18 +40,18 @@
   (into {} (map (fn [[k v]] [(f k) v]) m)))
 
 
-(defn run! [sql-map]
-  (let [[query & values] (sql/format sql-map)]
+(defn run! [sql-map & [{:keys [:format-opts]}]]
+  (let [[query & values] (apply sql/format sql-map (reduce into [] format-opts))]
     (js->clj (.run (.prepare @db query) (clj->js (or values []))) :keywordize-keys true)))
 
 
-(defn get [sql-map]
-  (let [[query & values] (sql/format sql-map)]
+(defn get [sql-map & [{:keys [:format-opts]}]]
+  (let [[query & values] (apply sql/format sql-map (reduce into [] format-opts))]
     (map-keys *transform-result-keys-fn* (js->clj (.get (.prepare @db query) (clj->js (or values [])))))))
 
 
-(defn all [sql-map]
-  (let [[query & values] (sql/format sql-map)]
+(defn all [sql-map & [{:keys [:format-opts]}]]
+  (let [[query & values] (apply sql/format sql-map (reduce into [] format-opts))]
     (map (partial map-keys *transform-result-keys-fn*)
          (js->clj (.all (.prepare @db query) (clj->js (or values [])))))))
 

--- a/server/district-server-db/test/tests/main_test.cljs
+++ b/server/district-server-db/test/tests/main_test.cljs
@@ -18,30 +18,70 @@
   ; (is (= (str @db) "[object Database]"))
 
   (is (map? (db/run! {:create-table [:my-doggos]
-                      :with-columns [[[:doggo/years :unsigned :integer]
-                                      [:doggo/description :varchar]]]})))
+                      :with-columns [[[:years :unsigned :integer]
+                                      [:description :varchar]]]})))
 
   (is (= (db/run! {:insert-into :my-doggos
-                   :columns [:doggo/years :doggo/description]
+                   :columns [:years :description]
                    :values [[1 "Good boy"]]})
          {:changes 1 :lastInsertRowid 1}))
 
-  (is (= (db/get {:select [:doggo/description]
+  (is (= (db/get {:select [:description]
                   :from [:my-doggos]
-                  :where [:= :doggo/years 1]})
+                  :where [:= :years 1]})
          {:description "Good boy"}))
 
-  (is (= (db/all {:select [:doggo/description]
+  (is (= (db/all {:select [:description]
                   :from [:my-doggos]
-                  :where [:= :doggo/years 1]})
+                  :where [:= :years 1]})
          [{:description "Good boy"}]))
 
   (is (= (db/run! {:insert-into :my-doggos
-                   :columns [:doggo/years :doggo/description]
+                   :columns [:years :description]
                    :values [[2 "Bad boy"]]})
          {:changes 1 :lastInsertRowid 2}))
 
-  (is (= (db/total-count {:select [:doggo/description]
+  (is (= (db/total-count {:select [:description]
                           :from [:my-doggos]
                           :limit 1})
          2)))
+
+(deftest test-db-w-ns
+
+  (let [opts {:format-opts {:allow-namespaced-names? true}}]
+
+    (is (map? (db/run! {:create-table [:my-doggos]
+                        :with-columns [[[:doggo/years :unsigned :integer]
+                                        [:doggo/description :varchar]
+                                        [:other/description :varchar]]]}
+                       opts)))
+
+    (is (= (db/run! {:insert-into :my-doggos
+                     :columns [:doggo/years :doggo/description]
+                     :values [[1 "Good boy"]]}
+                    opts)
+           {:changes 1 :lastInsertRowid 1}))
+
+    (is (= (db/get {:select [:doggo/description]
+                    :from [:my-doggos]
+                    :where [:= :doggo/years 1]}
+                   opts)
+           {:doggo/description "Good boy"}))
+
+    (is (= (db/all {:select [:doggo/description]
+                    :from [:my-doggos]
+                    :where [:= :doggo/years 1]}
+                   opts)
+           [{:doggo/description "Good boy"}]))
+
+    (is (= (db/run! {:insert-into :my-doggos
+                     :columns [:doggo/years :doggo/description]
+                     :values [[2 "Bad boy"]]}
+                    opts)
+           {:changes 1 :lastInsertRowid 2}))
+
+    (is (= (db/total-count {:select [:doggo/description]
+                            :from [:my-doggos]
+                            :limit 1})
+           2))
+    ))

--- a/version-tracking.edn
+++ b/version-tracking.edn
@@ -1,4 +1,9 @@
-[{:created-at "2023-03-01T15:42:46.624815",
+[{:created-at "2023-03-13T10:58:16.941441",
+  :version "23.3.13",
+  :description "Allow format options in db",
+  :libs ["server/district-server-db"],
+  :updated-at "2023-03-13T10:58:16.941842"}
+ {:created-at "2023-03-01T15:42:46.624815",
   :version "23.3.1",
   :description "Minor fixes to cljs-web3-next",
   :libs ["shared/cljs-web3-next",


### PR DESCRIPTION
The honeysql dependency of district-server-db module was updated to a more recent version (1.0.461). This version disables namespaces in DB columns by default, which older versions didn't, leading to breaking changes.

This PR allows specifying format-opts to the db functions (i.e., get, all, run!) to optionally enable namespaces in DB columns, among other opts. 