### PR TITLE
Calls the 'receive' fallback function when no fn is specified

### DIFF
--- a/browser/re-frame-web3-fx/src/district0x/re_frame/web3_fx.cljs
+++ b/browser/re-frame-web3-fx/src/district0x/re_frame/web3_fx.cljs
@@ -410,7 +410,9 @@
                     :on-success :on-error] :as method-args} (remove nil? fns)]
       (if instance
         (if tx-opts
-          (dispatch-on-tx-promi-event (web3-eth/contract-send instance method args tx-opts)
+          (dispatch-on-tx-promi-event (if (nil? method)
+                                        (web3-eth/send-transaction! web3 (merge tx-opts {:to (-> instance .-options .-address)}))
+                                        (web3-eth/contract-send instance method args tx-opts))
                                       (select-keys method-args tx-result-re-events))
           (web3-eth/contract-call instance method args {} (dispach-fn on-success on-error)))
         (apply method (concat [web3] args [(dispach-fn on-success on-error)]))))))

--- a/version-tracking.edn
+++ b/version-tracking.edn
@@ -1,7 +1,23 @@
 [{:created-at "2023-05-03T16:55:29.204147",
   :version "23.5.3",
   :description "Allow invoking the 'receive' fallback function",
-  :libs ["browser/re-frame-web3-fx"],
+  :libs
+  ["browser/district-ui-bundle"
+   "browser/district-ui-component-active-account"
+   "browser/district-ui-component-active-account-balance"
+   "browser/district-ui-component-tx-button"
+   "browser/district-ui-smart-contracts"
+   "browser/district-ui-web3-account-balances"
+   "browser/district-ui-web3-accounts"
+   "browser/district-ui-web3-balances"
+   "browser/district-ui-web3-chain"
+   "browser/district-ui-web3-sync-now"
+   "browser/district-ui-web3-tx"
+   "browser/district-ui-web3-tx-costs"
+   "browser/district-ui-web3-tx-id"
+   "browser/district-ui-web3-tx-log"
+   "browser/district-ui-web3-tx-log-core"
+   "browser/re-frame-web3-fx"],
   :updated-at "2023-05-03T16:55:29.204631"}
  {:created-at "2023-04-07T11:20:35.825484",
   :version "23.4.7",

--- a/version-tracking.edn
+++ b/version-tracking.edn
@@ -1,4 +1,9 @@
-[{:created-at "2023-04-07T11:20:35.825484",
+[{:created-at "2023-05-03T16:55:29.204147",
+  :version "23.5.3",
+  :description "Allow invoking the 'receive' fallback function",
+  :libs ["browser/re-frame-web3-fx"],
+  :updated-at "2023-05-03T16:55:29.204631"}
+ {:created-at "2023-04-07T11:20:35.825484",
   :version "23.4.7",
   :description "Migrate district-server-config to monorepo",
   :libs


### PR DESCRIPTION
:web3/send effect unifies making a call or a transaction to a contract.
It invokes _web3-eth/contract-call_ or _web3-eth/contract-send_ depending on the parameters. Also it makes proper handling of transaction event, such as _:on-tx-success, :on-tx-receipt, :on-tx-error_, etc.

However, to make a transaction with this effect you need to specify a method. What if you just want to send eth to the contract without calling any method (that is, to implicitly call the "receive" fallback function)? 

With this change, now you can set the "method" (i.e., function to invoke) to _nil_, thus invoking _web3-eth/send-transaction!_ over a given contract.