### PR TITLE
Implement backoff retry

### DIFF
--- a/server/district-server-smart-contracts/src/district/server/smart_contracts.cljs
+++ b/server/district-server-smart-contracts/src/district/server/smart_contracts.cljs
@@ -258,20 +258,42 @@
                              identity)]
     (transform-fn (remove-log-indexes sorted-logs))))
 
-(defn chunk->logs [transform-fn from-block skip-log-indexes events ignore-forward? [from to] ch-output]
+(defn get-events-with-retry [contract-instance contract event from to ch-logs re-try-attempts retry-count]
+  (web3-eth/get-past-events contract-instance
+                          event
+                          {:from-block from
+                           :to-block to}
+                          (fn [error events]
+                            (if (and error (< retry-count re-try-attempts))
+                              (do
+                                (let [wait-time (int (* 500 (inc retry-count) (inc (rand))))]
+                                  (log/info "Error fetching events. Retrying" {:retry-count retry-count
+                                                                               :contract contract
+                                                                               :event event
+                                                                               :from from
+                                                                               :to to
+                                                                               :error error
+                                                                               :wait-time wait-time})
+                                  (js/setTimeout
+                                    (fn []
+                                      (get-events-with-retry contract-instance contract event from to ch-logs re-try-attempts (inc retry-count)))
+                                    wait-time)))
+                              (let [logs (->> events
+                                              web3-helpers/js->cljkk
+                                              (map (partial enrich-event-log contract contract-instance)))]
+                                (async/put! ch-logs (if error [(with-meta {:err error} {:error? true})] logs)))))))
+
+(defn chunk->logs [transform-fn from-block skip-log-indexes events ignore-forward? re-try-attempts [from to] ch-output]
   ">! to ch-output for chunk [from to]: final sorted, skipped and transformed logs as async/ch."
   (let [sort-and-skip-logs' (partial sort-and-skip-logs transform-fn from-block skip-log-indexes)
         ch-logs (async/chan 1)
         event->logs (fn [[k [contract event]] ch-logs-output]
                       (let [contract-instance (instance-from-arg contract {:ignore-forward? ignore-forward?})]
-                        (web3-eth/get-past-events contract-instance
-                                                  event
-                                                  {:from-block from
-                                                   :to-block to}
-                                                  (fn [error events]
-                                                    (let [logs (map (partial enrich-event-log contract contract-instance)
-                                                                    (web3-helpers/js->cljkk events))]
-                                                      (async/put! ch-logs-output (or logs [(with-meta {:err error} {:error? true})])))))))]
+                        (log/debug "Processing chunk of blocks" {:contract contract
+                                                                 :event event
+                                                                 :from from
+                                                                 :to to})
+                        (get-events-with-retry contract-instance contract event from to ch-logs-output re-try-attempts 0)))]
     (go-loop [all-logs []
               [event & rest-events] events]
       (if event
@@ -290,8 +312,9 @@
   :skip-log-indexes, a set of tuples like [tx log-index] for the :from-block block that should be skipped."
   [events callback {:keys [from-block skip-log-indexes to-block block-step chunks-parallelism
                            ignore-forward? crash-on-event-fail?
-                           transform-fn on-chunk on-finish]
+                           transform-fn on-chunk on-finish re-try-attempts]
                     :or {chunks-parallelism 1
+                         re-try-attempts 3
                          transform-fn identity
                          on-chunk :do-nothing
                          on-finish :do-nothing}
@@ -302,7 +325,7 @@
 
   (let [ch-chunks-to-process (async/to-chan! (all-chunks from-block to-block block-step))
         ch-final-logs (async/chan 1)
-        chunk->logs' (partial chunk->logs transform-fn from-block skip-log-indexes events ignore-forward?)
+        chunk->logs' (partial chunk->logs transform-fn from-block skip-log-indexes events ignore-forward? re-try-attempts)
         chs-await-for-workers (for [n (range chunks-parallelism)]
                                (async/chan 1))
         workers (dotimes [n chunks-parallelism]

--- a/server/district-server-smart-contracts/src/district/server/smart_contracts.cljs
+++ b/server/district-server-smart-contracts/src/district/server/smart_contracts.cljs
@@ -348,8 +348,8 @@
           (when (fn? callback)
             (doseq [log chunk-logs]
               (doseq [res (try
-                            (if-let [?error (:error? (meta log))]
-                              (callback ?error nil)
+                            (if (:error? (meta log))
+                              (callback log nil)
                               (callback nil log))
                             (catch js/Error e
                               (when crash-on-event-fail?

--- a/version-tracking.edn
+++ b/version-tracking.edn
@@ -1,4 +1,12 @@
-[{:created-at "2023-05-03T16:55:29.204147",
+[{:created-at "2023-05-22T12:14:08.1815",
+  :version "23.5.22",
+  :description "Implements re-try if failed to retrieve smart contract events",
+  :libs
+  ["server/district-server-smart-contracts"
+   "server/district-server-web3-events"
+   "server/district-server-bundle"],
+  :updated-at "2023-05-22T12:15:07.171711"}
+ {:created-at "2023-05-03T16:55:29.204147",
   :version "23.5.3",
   :description "Allow invoking the 'receive' fallback function",
   :libs


### PR DESCRIPTION
This is a continuation of https://github.com/district0x/district-server-smart-contracts/pull/31

Some web3 providers force rate limits such that the amount of request you can do per second is capped. In that case, the provider sends an error if many requests are done in very short time.

This pull requests implements a retry mechanism with exponential backoff in case an error is received from the provider.