### PR TITLE
Get the most recently used account when changing accounts

### DIFF
--- a/browser/district-ui-web3-accounts/src/district/ui/web3_accounts/events.cljs
+++ b/browser/district-ui-web3-accounts/src/district/ui/web3_accounts/events.cljs
@@ -88,14 +88,14 @@
  (fn [{:keys [:db]
        {:keys [:eip55?]} :opts} [accounts]]
    (let [accounts (if eip55? (map eip55/address->checksum accounts) accounts) ;; support for EIP-55, needed ONLY until UI libraries are migrated to web3 1.0 which supports it OOB
-         active-account (if (contains? (set accounts) (queries/active-account db))
-                          (queries/active-account db)
-                          (first accounts))]
+         active-account (first accounts)
+         previous-account (queries/active-account db)]
      (merge
       (when (not= accounts (queries/accounts db))
         {:db (queries/assoc-accounts db accounts)
          :dispatch [::accounts-changed {:new accounts :old (queries/accounts db)}]})
-      {:dispatch-n [[::set-active-account active-account]]}))))
+      (when (not= previous-account active-account)
+        {:dispatch-n [[::set-active-account active-account]]})))))
 
 (re-frame/reg-event-fx
  ::accounts-changed

--- a/version-tracking.edn
+++ b/version-tracking.edn
@@ -1,6 +1,20 @@
-[{:created-at "2023-05-22T12:14:08.1815",
+[{:created-at "2023-07-26T15:41:14.924371",
+  :version "23.7.26",
+  :description "Get most recent address after selected account changed",
+  :libs
+  ["browser/district-ui-bundle"
+   "browser/district-ui-component-active-account"
+   "browser/district-ui-component-active-account-balance"
+   "browser/district-ui-component-tx-button"
+   "browser/district-ui-web3-account-balances"
+   "browser/district-ui-web3-accounts"
+   "browser/district-ui-web3-tx-id"
+   "browser/district-ui-web3-tx-log"],
+  :updated-at "2023-07-26T15:41:14.924488"}
+ {:created-at "2023-05-22T12:14:08.1815",
   :version "23.5.22",
-  :description "Implements re-try if failed to retrieve smart contract events",
+  :description
+  "Implements re-try if failed to retrieve smart contract events",
   :libs
   ["server/district-server-smart-contracts"
    "server/district-server-web3-events"


### PR DESCRIPTION
A recent change in MetaMask (I think this one: "Make eth_accounts return all permitted accounts" https://github.com/MetaMask/metamask-extension/pull/18516) breaks the active account functionality from d0x libs.

Now, when swapping or connecting/disconnecting accounts, Metamask returns all connected accounts, coming the active one the first in the list. (see https://docs.metamask.io/wallet/reference/provider-api/#accountschanged).

This PR adjusts district-ui-web3-accounts lib to handle account swapping accordingly.