### PR TITLE
Allow disabling wallet unlock request on init

### DIFF
--- a/browser/district-ui-web3/src/district/ui/web3.cljs
+++ b/browser/district-ui-web3/src/district/ui/web3.cljs
@@ -15,7 +15,7 @@
 (s/def ::url string?)
 (s/def ::wait-for-inject-ms number?)
 (s/def ::opts (s/keys :req-un [::url]
-                      :opt-un [::wait-for-inject-ms]))
+                      :opt-un [::wait-for-inject-ms ::authorize-on-init?]))
 
 (defn start [opts]
   (s/assert ::opts opts)

--- a/version-tracking.edn
+++ b/version-tracking.edn
@@ -1,6 +1,23 @@
-[{:created-at "2023-07-26T15:41:14.924371",
+[{:created-at "2023-08-07T09:43:15.122447",
+  :version "23.8.7",
+  :description "Allow disabling wallet unlock request (eth_requestAccounts) on init",
+  :libs
+  ["browser/district-ui-web3-account-balances"
+   "browser/district-ui-web3-tx-costs"
+   "browser/district-ui-web3"
+   "browser/district-ui-web3-balances"
+   "browser/district-ui-web3-tx-log"
+   "browser/district-ui-web3-chain"
+   "browser/district-ui-web3-sync-now"
+   "browser/district-ui-web3-accounts"
+   "browser/district-ui-web3-tx-id"
+   "browser/district-ui-web3-tx"
+   "browser/district-ui-web3-tx-log-core"],
+  :updated-at "2023-08-07T09:43:15.122839"}
+ {:created-at "2023-07-26T15:41:14.924371",
   :version "23.7.26",
-  :description "Get most recent address after selected account changed",
+  :description
+  "Get most recent address after selected account changed",
   :libs
   ["browser/district-ui-bundle"
    "browser/district-ui-component-active-account"


### PR DESCRIPTION
district-web3-ui library checks whether there is a web3 provider injected in the browser (e.g., by metamask). If detected, it directly requests the user to unlock its wallet and grant permission to the website. In other words, every user will receive the unlock wallet popup as soon as they open the website. This could discourage some users which might want to navigate the page before triggering any web3 action.

This PR introduces a parameter to disable wallet unlock request when initializing the page so it can be done on demand later (for example, adding a "connect wallet" button). So, if there is already an account connected, it initializes the web3 provider, if not it just silently continues.
To preserve legacy behavior, it request wallet unlock by default. It is only disabled if explicitly specified :authorize-on-init false