### PR TITLE
Sendgrid fix and improvements

### DIFF
--- a/shared/district-sendgrid/src/district/sendgrid.cljs
+++ b/shared/district-sendgrid/src/district/sendgrid.cljs
@@ -38,7 +38,7 @@
                                     :value content}]
                          :template_id template-id}
                         body)]
-        (async/take! (http/post sendgrid-public-api {:headers headers} {:json-params body})
+        (async/take! (http/post sendgrid-public-api {:headers headers :json-params body})
                      (fn [res] (if (= true (:success res))
                                  (on-success res)
                                  (on-error res))))

--- a/shared/district-sendgrid/src/district/sendgrid.cljs
+++ b/shared/district-sendgrid/src/district/sendgrid.cljs
@@ -15,7 +15,7 @@
 ;   https://docs.sendgrid.com/api-reference/mail-send/mail-send
 (defn send-email
   [{:keys [:from :to :subject :content :substitutions :on-success :on-error :template-id :api-key :body :headers
-           :print-mode?]}]
+           :dynamic-template-data :print-mode?]}]
   (if (and (not api-key)
            (not print-mode?))
     (throw (js/Error. "Missing api-key to send email to sendgrid"))
@@ -26,13 +26,15 @@
         (println "To:" to)
         (println "Subject:" subject)
         (println "Content:" content)
-        (println "Substitutions:" substitutions))
+        (println "Substitutions:" substitutions)
+        (println "Dynamic-template-data:" dynamic-template-data))
       (let [headers (merge {"Authorization" (str "Bearer " api-key)
                             "Content-Type" "application/json"} headers)
             body (merge {:from {:email from}
-                         :personalizations [{:to [{:email to}]
-                                             ;; Substitutions are in format e.g ":header", so (str :header) works well
-                                             :substitutions (into {} (map (fn [[k v]] [(str k) v]) substitutions))}]
+                         :personalizations [(cond-> {:to [{:email to}]}
+                                                    dynamic-template-data (assoc :dynamic_template_data dynamic-template-data)
+                                                    ;; Substitutions are in format e.g ":header", so (str :header) works well
+                                                    substitutions (assoc :substitutions (into {} (map (fn [[k v]] [(str k) v]) substitutions))))]
                          :subject subject
                          :content [{:type "text/html"
                                     :value content}]

--- a/version-tracking.edn
+++ b/version-tracking.edn
@@ -1,7 +1,11 @@
-[{:created-at "2023-08-07T16:00:11.178403",
+[{:created-at "2023-09-25T08:23:14.679113",
+  :version "23.9.25",
+  :description "Fix sendgrid api request",
+  :libs ["shared/district-sendgrid"],
+  :updated-at "2023-09-25T08:23:14.67936"}
+ {:created-at "2023-08-07T16:00:11.178403",
   :version "23.8.7",
-  :description
-  "Added missing dependencies",
+  :description "Added missing dependencies",
   :libs
   ["browser/district-ui-bundle"
    "browser/district-ui-component-active-account"
@@ -9,7 +13,7 @@
    "browser/district-ui-component-tx-button"
    "browser/district-ui-smart-contracts"],
   :updated-at "2023-08-07T16:00:11.178403"}
-{:created-at "2023-08-07T09:43:15.122447",
+ {:created-at "2023-08-07T09:43:15.122447",
   :version "23.8.7",
   :description
   "Allow disabling wallet unlock request (eth_requestAccounts) on init",

--- a/version-tracking.edn
+++ b/version-tracking.edn
@@ -1,6 +1,6 @@
 [{:created-at "2023-09-25T08:23:14.679113",
   :version "23.9.25",
-  :description "Fix sendgrid api request",
+  :description "Fix and improve sendgrid api request",
   :libs ["shared/district-sendgrid"],
   :updated-at "2023-09-25T08:23:14.67936"}
  {:created-at "2023-08-07T16:00:11.178403",


### PR DESCRIPTION
Sendgrid lib was failing to send HTTP post parameters as cljs-http.client/post expects a single map for both headers and parameters. This PR fixes that.

Additionally, this adds support for using dynamic templates. If specified, in addition to 'substitutions' (or instead of), it can send 'dynamic_template_data' such that template placeholders are replaced with specified parameters.