### PR TITLE
avoid duplicated events

### DIFF
--- a/browser/district-ui-web3-tx/src/district/ui/web3_tx/events.cljs
+++ b/browser/district-ui-web3-tx/src/district/ui/web3_tx/events.cljs
@@ -125,7 +125,8 @@
   (fn [{:keys [:db]} [{:keys [:instance :fn :tx-opts :args] :as opts}]]
     {:web3/send
      {:web3 (web3-queries/web3 db)
-      :fns [(merge opts
+      :fns [(-> opts
+                (merge
                    {:instance instance
                     :fn fn
                     :args args
@@ -138,7 +139,8 @@
                     :on-tx-hash-error [::tx-hash-error opts]
                     :on-tx-receipt [::tx-receipt opts]
                     :on-tx-success [::tx-success opts]
-                    :on-tx-error [::tx-error opts]})]}}))
+                    :on-tx-error [::tx-error opts]})
+                (dissoc :on-tx-hash-n :on-tx-hash-error-n :on-tx-receipt-n :on-tx-success-n :on-tx-error-n))]}}))
 
 
 (defn- concat-callback-effects [callback callback-n args]

--- a/version-tracking.edn
+++ b/version-tracking.edn
@@ -1,4 +1,15 @@
-[{:created-at "2023-10-02T17:04:43.090523",
+[{:created-at "2023-10-06T11:54:02.598576",
+  :version "23.10.6",
+  :description "Avoid duplicated events",
+  :libs
+  ["browser/district-ui-web3-tx-costs"
+   "browser/district-ui-web3-tx-log"
+   "browser/district-ui-web3-tx-id"
+   "browser/district-ui-web3-tx"
+   "browser/district-ui-web3-tx-log-core"
+   "browser/district-ui-bundle"],
+  :updated-at "2023-10-06T11:54:02.598838"}
+ {:created-at "2023-10-02T17:04:43.090523",
   :version "23.10.2",
   :description "improve switch chain error handling",
   :libs


### PR DESCRIPTION
When using `web-tx.events/send-tx` you can react to the transaction events by using `:on-tx-hash-error`, `:on-tx-receipt`, `:on-tx-success` and `:on-tx-error`. They also have a "-n" version to trigger multiple event handlers. That is, `:on-tx-hash-error-n`, `:on-tx-receipt-n`, `:on-tx-success-n` and `:on-tx-error-n`

However, when specifying an "-n" version, the events were triggered twice. That is because _web3-tx_ triggers the -n events into its wrappers (`::tx-hash`, `::tx-hash-error`, `::tx-success` and `::tx-error`) whereas _re-frame-web3-fx_ also triggers the -n events. https://github.com/district0x/d0x-libs/blob/4d7978fde4f500afae06020ac01e2eb5e0aa5e44/browser/re-frame-web3-fx/src/district0x/re_frame/web3_fx.cljs#L367

To avoid this, this PR modifies _web3-tx_ so it does not forward the "-n" options to _re-frame-web3-fx_, so it will be the unique responsible of sending the events to the "-n" handlers trough its wrappers.