### PR TITLE
Connect on init

### DIFF
--- a/browser/district-ui-web3-accounts/test/tests/all.cljs
+++ b/browser/district-ui-web3-accounts/test/tests/all.cljs
@@ -29,9 +29,9 @@
   (run-test-async
     (let [accounts (subscribe [::subs/accounts])
           active-account (subscribe [::subs/active-account])
-          mock-accounts ["0x4a5c034cc587a219e5099eac1e7b92f468b77129"
-                         "0x701de50ef02bd981feccc1cc07b8938a1a8d64c2"]
-          mock-accounts2 ["0x93023b437dc89769e0088ceafb9f7cdbf149814c"]]
+          mock-accounts ["0x4a5C034Cc587A219E5099EaC1E7B92f468B77129"
+                         "0x701DE50EF02bD981FECCC1cc07B8938a1a8d64c2"]
+          mock-accounts2 ["0x93023B437dC89769E0088CEAfB9f7cdBf149814C"]]
 
       (set-response mock-accounts)
 

--- a/browser/district-ui-web3/src/district/ui/web3.cljs
+++ b/browser/district-ui-web3/src/district/ui/web3.cljs
@@ -15,7 +15,7 @@
 (s/def ::url string?)
 (s/def ::wait-for-inject-ms number?)
 (s/def ::opts (s/keys :req-un [::url]
-                      :opt-un [::wait-for-inject-ms ::authorize-on-init?]))
+                      :opt-un [::wait-for-inject-ms ::connect-on-init? ::authorize-on-init?]))
 
 (defn start [opts]
   (s/assert ::opts opts)

--- a/browser/district-ui-web3/src/district/ui/web3/events.cljs
+++ b/browser/district-ui-web3/src/district/ui/web3/events.cljs
@@ -11,16 +11,18 @@
 
 (def interceptors [trim-v])
 
-; opts - can have 3 keys: :wait-for-inject-ms, :url (Ethereum node URL, e.g.
-;        where Truffle is running) and :authorize-on-init
+; opts - can have 4 keys: :wait-for-inject-ms, :url (Ethereum node URL, e.g.
+;        where Truffle is running), :connect-on-init? and :authorize-on-init?
 (reg-event-fx
   ::start
   interceptors
-  (fn [_ [{:keys [:wait-for-inject-ms] :as opts}]]
-    (if (web3-injected?)
-      {:dispatch [::init-web3 opts]}
-      ;; Sometimes web3 gets injected with delay, so we'll give it one more chance
-      {:dispatch-later [{:ms (or wait-for-inject-ms 1500) :dispatch [::init-web3 opts]}]})))
+  (fn [_ [{:keys [:wait-for-inject-ms :connect-on-init?]
+           :or {connect-on-init? true} :as opts}]]
+    (when connect-on-init?
+      (if (web3-injected?)
+        {:dispatch [::init-web3 opts]}
+        ;; Sometimes web3 gets injected with delay, so we'll give it one more chance
+        {:dispatch-later [{:ms (or wait-for-inject-ms 1500) :dispatch [::init-web3 opts]}]}))))
 
 
 (reg-event-fx

--- a/version-tracking.edn
+++ b/version-tracking.edn
@@ -1,4 +1,25 @@
-[{:created-at "2023-10-13T23:14:39.974538",
+[{:created-at "2023-11-30T14:03:28.28578",
+  :version "23.11.30",
+  :description "Allow disabling connecting wallet on init",
+  :libs
+  ["browser/district-ui-bundle"
+   "browser/district-ui-component-active-account"
+   "browser/district-ui-component-active-account-balance"
+   "browser/district-ui-component-tx-button"
+   "browser/district-ui-smart-contracts"
+   "browser/district-ui-web3-account-balances"
+   "browser/district-ui-web3-tx-costs"
+   "browser/district-ui-web3"
+   "browser/district-ui-web3-balances"
+   "browser/district-ui-web3-tx-log"
+   "browser/district-ui-web3-chain"
+   "browser/district-ui-web3-sync-now"
+   "browser/district-ui-web3-accounts"
+   "browser/district-ui-web3-tx-id"
+   "browser/district-ui-web3-tx"
+   "browser/district-ui-web3-tx-log-core"],
+  :updated-at "2023-10-11T14:03:28.285983"}
+ {:created-at "2023-10-13T23:14:39.974538",
   :version "23.10.13",
   :description "Support IPFS auth, respect :forwards-to for UI smart contracts",
   :libs


### PR DESCRIPTION
Adds an extra option to avoid connecting the web3 wallet when initializing the web3 module. This way, the wallet or account connection can be handled later on demand, for example using a "Connect Wallet" button.