### PR TITLE
Implement store & load last event checkpoint via function

### DIFF
--- a/server/district-server-config/deps.edn
+++ b/server/district-server-config/deps.edn
@@ -6,7 +6,7 @@
  {org.clojure/clojure {:mvn/version "1.11.1"},
   thheller/shadow-cljs {:mvn/version "2.19.8"},
   org.clojure/clojurescript {:mvn/version "1.11.60"},
-  com.github.pkpkpk/cljs-node-io {:mvn/version "2.0.332"},
+  com.github.pkpkpk/cljs-node-io {:mvn/version "2.0.339"},
   mount/mount {:mvn/version "0.1.16"}},
  :install-deps true,
  :aliases

--- a/server/district-server-web3-events/package.json
+++ b/server/district-server-web3-events/package.json
@@ -4,5 +4,8 @@
     "buffer": "6.0.3",
     "jsedn": "0.4.1",
     "web3": "1.7.3"
+  },
+  "devDependencies": {
+    "source-map-support": "^0.5.21"
   }
 }

--- a/server/district-server-web3-events/yarn.lock
+++ b/server/district-server-web3-events/yarn.lock
@@ -506,6 +506,11 @@ bs58check@^2.1.2:
     create-hash "^1.1.0"
     safe-buffer "^5.1.2"
 
+buffer-from@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
 buffer-to-arraybuffer@^0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz#6064a40fa76eb43c723aba9ef8f6e1216d10511a"
@@ -2101,6 +2106,19 @@ simple-get@^2.7.0:
     decompress-response "^3.3.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
+
+source-map-support@^0.5.21:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 sshpk@^1.7.0:
   version "1.17.0"

--- a/version-tracking.edn
+++ b/version-tracking.edn
@@ -1,4 +1,9 @@
-[{:created-at "2024-01-24T22:59:30.399074",
+[{:created-at "2024-02-01T21:09:01.501055",
+  :version "24.2.1",
+  :description "Allow custom fn to store & load last-processed-block",
+  :libs ["server/district-server-web3-events"],
+  :updated-at "2024-02-01T21:09:01.501324"}
+ {:created-at "2024-01-24T22:59:30.399074",
   :version "24.1.24",
   :description "Retrying deployment (failed CI build on the previous one)",
   :libs


### PR DESCRIPTION
Thus far the `district.server.web3-events` allowed the last block synced to be stored in a file. This is problematic when
  1) there are multiple instances of the server running (e.g. for load
     balancing)
  2) when the filesystem gets destroyed between builds (e.g. docker
     containers)

This change allows to pass in `:load-checkpoint` and `:save-checkpoint` functions whith let the developer do the storing & loading for example to the database.