### PR TITLE
Fix skip log indexes for checkpoint from DB

### DIFF
--- a/server/district-server-smart-contracts/src/district/server/smart_contracts.cljs
+++ b/server/district-server-smart-contracts/src/district/server/smart_contracts.cljs
@@ -324,7 +324,7 @@
 
   (let [ch-chunks-to-process (async/to-chan! (all-chunks from-block to-block block-step))
         ch-final-logs (async/chan 1)
-        chunk->logs' (partial chunk->logs transform-fn from-block skip-log-indexes events ignore-forward? re-try-attempts)
+        chunk->logs' (partial chunk->logs transform-fn from-block (set skip-log-indexes) events ignore-forward? re-try-attempts)
         chs-await-for-workers (for [n (range chunks-parallelism)]
                                (async/chan 1))
         workers (dotimes [n chunks-parallelism]


### PR DESCRIPTION
The skip-log-indexes needs to be a Set (not a vector). It works when written to a file but the DB stores it as JSON and the value comes back as vector, breaking the code.