### PR TITLE
Extends DB lib to support async calls

### DIFF
--- a/server/district-server-db/deps.edn
+++ b/server/district-server-db/deps.edn
@@ -7,6 +7,7 @@
   thheller/shadow-cljs {:mvn/version "2.19.8"},
   org.clojure/clojurescript {:mvn/version "1.11.60"},
   is.d0x/district-server-config {:mvn/version "LATEST"},
+  district0x/async-helpers {:mvn/version "0.1.3"},
   nilenso/honeysql-postgres {:mvn/version "0.4.112"},
   honeysql/honeysql {:mvn/version "1.0.461"},
   mount/mount {:mvn/version "0.1.16"}},

--- a/server/district-server-db/src/district/server/db/async/postgresql.cljs
+++ b/server/district-server-db/src/district/server/db/async/postgresql.cljs
@@ -1,0 +1,42 @@
+(ns district.server.db.async.postgresql
+  (:require
+    [district.server.db.db-client :as db-client]
+    [cljs.core.async :refer [go <!]]
+    [district.shared.async-helpers :refer [<? safe-go]]
+    [district.server.config :refer [config]]
+    [mount.core :as mount :refer [defstate]]
+    ["pg" :refer [Client]]))
+
+(declare start)
+(declare stop)
+(defstate ^{:on-reload :noop} db
+          :start (start (merge (:db @config)
+                               (:db (mount/args))))
+          :stop (stop db))
+
+(defrecord PostgreSQL []
+  db-client/DBClient
+
+  (start [this {:keys [:user :password :host :port :database] :as args}]
+    (let [client (Client. #js {:user user
+                  :password password
+                  :host host
+                  :port port
+                  :database database})]
+      (assoc this :js-client (-> (.connect client)
+                                 (.then (fn [] client))))))
+
+  (stop [this]
+    (.end (:js-client this)))
+
+  (run! [this query values]
+    (safe-go
+      (js->clj (.-rows (<? (.query (<! (:js-client this)) query values))))))
+
+  (get [this query values]
+    (safe-go
+      (first (<? (db-client/all this query values)))))
+
+  (all [this query values]
+    (db-client/run! this query values)))
+

--- a/server/district-server-db/src/district/server/db/async/postgresql.cljs
+++ b/server/district-server-db/src/district/server/db/async/postgresql.cljs
@@ -1,18 +1,10 @@
 (ns district.server.db.async.postgresql
   (:require
-    [district.server.db.db-client :as db-client]
     [cljs.core.async :refer [go <!]]
+    [district.server.db.db-client :as db-client]
     [district.shared.async-helpers :refer [<? safe-go]]
     [district.server.config :refer [config]]
-    [mount.core :as mount :refer [defstate]]
     ["pg" :refer [Client]]))
-
-(declare start)
-(declare stop)
-(defstate ^{:on-reload :noop} db
-          :start (start (merge (:db @config)
-                               (:db (mount/args))))
-          :stop (stop db))
 
 (defrecord PostgreSQL []
   db-client/DBClient

--- a/server/district-server-db/src/district/server/db/async/sqlite.cljs
+++ b/server/district-server-db/src/district/server/db/async/sqlite.cljs
@@ -4,16 +4,8 @@
     [district.server.config :refer [config]]
     [district.server.db.db-client :as db-client]
     [district.server.db.honeysql-extensions :refer [load-sqlite-extensions]]
-    [mount.core :as mount :refer [defstate]]
     ["sqlite3" :as sqlite3]
     ["sqlite" :refer [open]]))
-
-(declare start)
-(declare stop)
-(defstate ^{:on-reload :noop} db
-          :start (start (merge (:db @config)
-                               (:db (mount/args))))
-          :stop (stop db))
 
 (defrecord SQLite []
   db-client/DBClient

--- a/server/district-server-db/src/district/server/db/async/sqlite.cljs
+++ b/server/district-server-db/src/district/server/db/async/sqlite.cljs
@@ -1,0 +1,40 @@
+(ns district.server.db.async.sqlite
+  (:require
+    [cljs.core.async :refer [go <!]]
+    [district.server.config :refer [config]]
+    [district.server.db.db-client :as db-client]
+    [district.server.db.honeysql-extensions :refer [load-sqlite-extensions]]
+    [mount.core :as mount :refer [defstate]]
+    ["sqlite3" :as sqlite3]
+    ["sqlite" :refer [open]]))
+
+(declare start)
+(declare stop)
+(defstate ^{:on-reload :noop} db
+          :start (start (merge (:db @config)
+                               (:db (mount/args))))
+          :stop (stop db))
+
+(defrecord SQLite []
+  db-client/DBClient
+
+  (start [this {:keys [:path :opts] :as args}]
+    (load-sqlite-extensions)
+    (assoc this :js-client (open #js {:filename path
+                                      :driver sqlite3/Database})))
+
+  (stop [this]
+    (.close (:js-client this)))
+
+  (run! [this query values]
+    (go
+      (js->clj (<! (.run (<! (:js-client this)) query values)))))
+
+  (get [this query values]
+    (go
+      (js->clj (<! (.get (<! (:js-client this)) query values)))))
+
+  (all [this query values]
+    (go
+      (js->clj (<! (.all (<! (:js-client this)) query values))))))
+

--- a/server/district-server-db/src/district/server/db/db_client.cljs
+++ b/server/district-server-db/src/district/server/db/db_client.cljs
@@ -1,0 +1,8 @@
+(ns district.server.db.db-client)
+
+(defprotocol DBClient
+  (start [this args])
+  (stop [this])
+  (run! [this query values])
+  (get [this query values])
+  (all [this query values]))

--- a/server/district-server-db/src/district/server/db/honeysql_extensions.cljs
+++ b/server/district-server-db/src/district/server/db/honeysql_extensions.cljs
@@ -12,31 +12,31 @@
     (first x)
     x))
 
-
-(defmethod sql-format/format-clause :insert-or-replace-into [[_ table] _]
-  (if (and (sequential? table) (sequential? (first table)))
-    (str "INSERT OR REPLACE INTO "
-         (sql-format/to-sql (ffirst table))
-         " (" (sql-format/comma-join (map sql-format/to-sql (second (first table)))) ") "
-         (sql-format/to-sql (second table)))
-    (str "INSERT OR REPLACE INTO " (to-sql table))))
-
-
-(extend-protocol sql-format/ToSql
-  boolean
-  (to-sql [x]
-    (if x 1 0)))
+(defn load-sqlite-extensions []
+  (defmethod sql-format/format-clause :insert-or-replace-into [[_ table] _]
+    (if (and (sequential? table) (sequential? (first table)))
+      (str "INSERT OR REPLACE INTO "
+           (sql-format/to-sql (ffirst table))
+           " (" (sql-format/comma-join (map sql-format/to-sql (second (first table)))) ") "
+           (sql-format/to-sql (second table)))
+      (str "INSERT OR REPLACE INTO " (to-sql table))))
 
 
-(defmethod sql-format/format-clause :create-index [[_ tablename] _]
-  (str "CREATE INDEX " (-> tablename
-                         get-first
-                         to-sql)))
+  (extend-protocol sql-format/ToSql
+    boolean
+    (to-sql [x]
+      (if x 1 0)))
 
 
-(defmethod sql-format/format-clause :on [[_ [tablename column]] _]
-  (str "ON " (get-first (to-sql tablename)) " " (paren-wrap (to-sql column))))
+  (defmethod sql-format/format-clause :create-index [[_ tablename] _]
+    (str "CREATE INDEX " (-> tablename
+                           get-first
+                           to-sql)))
 
 
-(defmethod sql-format/format-clause :cascade [[op v] _]
-  (when v (str "CASCADE" )))
+  (defmethod sql-format/format-clause :on [[_ [tablename column]] _]
+    (str "ON " (get-first (to-sql tablename)) " " (paren-wrap (to-sql column))))
+
+
+  (defmethod sql-format/format-clause :cascade [[op v] _]
+    (when v (str "CASCADE" ))))

--- a/server/district-server-db/src/district/server/db/sqlite.cljs
+++ b/server/district-server-db/src/district/server/db/sqlite.cljs
@@ -3,15 +3,7 @@
     [district.server.config :refer [config]]
     [district.server.db.db-client :as db-client]
     [district.server.db.honeysql-extensions :refer [load-sqlite-extensions]]
-    [mount.core :as mount :refer [defstate]]
     ["better-sqlite3" :as Sqlite3Database]))
-
-(declare start)
-(declare stop)
-(defstate ^{:on-reload :noop} db
-          :start (start (merge (:db @config)
-                               (:db (mount/args))))
-          :stop (stop db))
 
 (defrecord SQLite []
   db-client/DBClient

--- a/server/district-server-db/src/district/server/db/sqlite.cljs
+++ b/server/district-server-db/src/district/server/db/sqlite.cljs
@@ -1,0 +1,34 @@
+(ns district.server.db.sqlite
+  (:require
+    [district.server.config :refer [config]]
+    [district.server.db.db-client :as db-client]
+    [district.server.db.honeysql-extensions :refer [load-sqlite-extensions]]
+    [mount.core :as mount :refer [defstate]]
+    ["better-sqlite3" :as Sqlite3Database]))
+
+(declare start)
+(declare stop)
+(defstate ^{:on-reload :noop} db
+          :start (start (merge (:db @config)
+                               (:db (mount/args))))
+          :stop (stop db))
+
+(defrecord SQLite []
+  db-client/DBClient
+
+  (start [this {:keys [:path :opts] :as args}]
+    (load-sqlite-extensions)
+    (assoc this :js-client (new Sqlite3Database path (clj->js opts))))
+
+  (stop [this]
+    (.close (:js-client this)))
+
+  (run! [this query values]
+    (js->clj (.run (.prepare (:js-client this) query) values) :keywordize-keys true))
+
+  (get [this query values]
+    (js->clj (.get (.prepare (:js-client this) query) values)))
+
+  (all [this query values]
+    (js->clj (.all (.prepare (:js-client this) query) values))))
+

--- a/server/district-server-db/src/district/server/db/utils.cljs
+++ b/server/district-server-db/src/district/server/db/utils.cljs
@@ -1,0 +1,18 @@
+(ns district.server.db.utils)
+
+
+(defn total-count-query [sql-map & [{:keys [:count-distinct-column :count-select]
+                                     :or {count-select [:%count.*]}}]]
+  (let [select (if (contains? (set (:modifiers sql-map)) :distinct)
+                 [(sql/call :count-distinct (or count-distinct-column (first (:select sql-map))))]
+                 count-select)]
+    (-> sql-map
+        (assoc :select select)
+        (dissoc :offset :limit :order-by))))
+
+(defn order-by-similarity [col-name s & [{:keys [:suffix :prefix]}]]
+  (sql/call :case
+            [:= col-name (str prefix s suffix)] 1
+            [:like col-name (str prefix s "%" suffix)] 2
+            [:like col-name (str prefix "%" s "%" suffix)] 3
+            :else 4))

--- a/server/district-server-db/src/district/server/db_async.cljs
+++ b/server/district-server-db/src/district/server/db_async.cljs
@@ -1,12 +1,14 @@
-(ns district.server.db
+(ns district.server.db-async
   (:refer-clojure :exclude [get run!])
   (:require
+    [cljs.core.async :refer [go <!]]
     [clojure.string :as string]
     [district.server.config :refer [config]]
+    [district.server.db.async.sqlite :as sqlite]
+    [district.server.db.async.postgresql :as postgresql]
     [district.server.db.honeysql-extensions]
     [district.server.db.db-client :as db-client]
     [district.server.db.utils :as utils]
-    [district.server.db.sqlite :as sqlite]
     [honeysql-postgres.format]
     [honeysql.core :as sql]
     [honeysql.format :as sql-format]
@@ -15,13 +17,16 @@
 (declare start)
 (declare stop)
 (defstate ^{:on-reload :noop} db
-  :start (start (merge (:db @config)
-                       (:db (mount/args))))
-  :stop (stop db))
+          :start (start (merge (:db @config)
+                               (:db (mount/args))))
+          :stop (stop db))
 
 (def ^:dynamic *transform-result-keys-fn* (atom nil))
 
-(defn start [{:keys [:path :opts :transform-result-keys-fn :sql-name-transform-fn]
+(defn start [{:keys [:db-client
+                     :path :opts ; sqlite
+                     :user :password :host :port :database ; postgresql
+                     :transform-result-keys-fn :sql-name-transform-fn]
               :as args
               :or {path ":memory:"
                    sql-name-transform-fn (comp #(string/replace % "_STAR_" "*")
@@ -32,7 +37,10 @@
   (set! *transform-result-keys-fn* transform-result-keys-fn)
   (set! sql-format/*name-transform-fn* sql-name-transform-fn)
 
-  (let [client (sqlite/->SQLite)]
+  (let [client (case db-client
+                 :sqlite (sqlite/->SQLite)
+                 :postgresql (postgresql/->PostgreSQL)
+                 (sqlite/->SQLite))]
     (db-client/start client args)))
 
 
@@ -50,15 +58,18 @@
 
 
 (defn get [sql-map & [{:keys [:format-opts]}]]
-  (let [[query & values] (apply sql/format sql-map (reduce into [] format-opts))]
-    (map-keys *transform-result-keys-fn* (db-client/get @db query (clj->js (or values []))))))
+  (go
+    (let [[query & values] (apply sql/format sql-map (reduce into [] format-opts))]
+      (map-keys *transform-result-keys-fn* (<! (db-client/get @db query (clj->js (or values []))))))))
 
 
 (defn all [sql-map & [{:keys [:format-opts]}]]
-  (let [[query & values] (apply sql/format sql-map (reduce into [] format-opts))]
-    (map (partial map-keys *transform-result-keys-fn*)
-         (db-client/all @db query (clj->js (or values []))))))
+  (go
+    (let [[query & values] (apply sql/format sql-map (reduce into [] format-opts))]
+      (map (partial map-keys *transform-result-keys-fn*)
+           (<! (db-client/all @db query (clj->js (or values []))))))))
 
 
 (defn total-count [sql-map & [opts]]
-  (second (first (get (utils/total-count-query sql-map opts)))))
+  (go
+    (second (first (<! (get (utils/total-count-query sql-map opts)))))))

--- a/version-tracking.edn
+++ b/version-tracking.edn
@@ -1,4 +1,10 @@
-[{:created-at "2024-02-29T00:25:30.200208",
+[{:created-at "2024-06-19T16:09:00.514147",
+  :version "24.6.19",
+  :description "Extend DB lib to support async calls",
+  :libs ["server/district-server-db"
+         "server/district-server-bundle"],
+  :updated-at "2024-06-19T16:09:00.514549"}
+ {:created-at "2024-02-29T00:25:30.200208",
   :version "24.2.29",
   :description "Fix skip log indexes when loading checkpoint from DB",
   :libs ["server/district-server-smart-contracts"],


### PR DESCRIPTION
Current implementation of district-server-db is tight to sqlite using synchronous calls. This limits its usage in production environment, where other alternatives allowing more concurrency are expected, as postgresql using asynchronous calls.

This PR extends the district-server-db library to support asynchronous calls and implement different DB clients. More concretely, this PR implements support for postgresql and both sync and async sqlite.
Besides, it defines a dbclient protocol so it's easier to swap between clients (for example using sqlite for development and postgresql for production) and also provides a common ground to implement other db clients in the future (e.g., mysql).