### PR TITLE
Web3 events fixes

### DIFF
--- a/server/district-server-web3-events/src/district/server/web3_events.cljs
+++ b/server/district-server-web3-events/src/district/server/web3_events.cljs
@@ -159,7 +159,9 @@
           (fn [err checkpoint]
             (web3-eth/get-block-number
               @web3
-              (fn [_err-block last-block-number]
+              (fn [err-block last-block-number]
+                (when (or err-block (nil? last-block-number))
+                  (throw (js/Error. "Failed to get current block number")))
                 (let [{:keys [last-processed-block processed-log-indexes]} checkpoint
                       next-block-to-process (max 0 (- last-processed-block backtrack))]
                   (if skip-past-events-replay?

--- a/server/district-server-web3-events/src/district/server/web3_events.cljs
+++ b/server/district-server-web3-events/src/district/server/web3_events.cljs
@@ -161,16 +161,13 @@
               @web3
               (fn [_err-block last-block-number]
                 (let [{:keys [last-processed-block processed-log-indexes]} checkpoint
-                      ; Current backtrack parameter is not considered (and therefore next-block-to-process neither)
-                      ; If want to use it, it needs to be made sure that event handlers are idempotent (i.e. can be run twice without the DB changing)
-                      ; This is not the case for FundsIn/FundsOut and some other messages in Ethlance for example
                       next-block-to-process (max 0 (- last-processed-block backtrack))]
                   (if skip-past-events-replay?
                     (start-dispatching-latest-events! events (inc last-block-number))
                     (smart-contracts/replay-past-events-in-order
                       events
                       dispatch
-                      {:from-block (max last-processed-block from-block 0)
+                      {:from-block (max next-block-to-process from-block 0)
                        :crash-on-event-fail? crash-on-event-fail?
                        :skip-log-indexes processed-log-indexes
                        :to-block last-block-number

--- a/version-tracking.edn
+++ b/version-tracking.edn
@@ -1,4 +1,10 @@
-[{:created-at "2024-10-15T12:45:02.502733",
+[{:created-at "2025-06-26T10:54:13.635646",
+  :version "25.6.26",
+  :description "Re-enable backtrack and throw error if cannot get block number",
+  :libs ["server/district-server-web3-events",
+         "server/district-server-bundle"],
+  :updated-at "2025-06-26T10:54:13.635728"}
+ {:created-at "2024-10-15T12:45:02.502733",
   :version "24.10.15",
   :description "district-server-web3-events: make callback-after-past-events configurable",
   :libs ["server/district-server-web3-events"],
@@ -75,7 +81,8 @@
   :updated-at "2024-01-24T23:04:49.497368"}
  {:created-at "2024-01-15T22:59:30.399074",
   :version "24.1.22",
-  :description "Retrying deploy x3: cljs-web3-next connected? + some logging",
+  :description
+  "Retrying deploy x3: cljs-web3-next connected? + some logging",
   :libs
   ["shared/district-shared-bundle"
    "shared/cljs-web3-next"
@@ -109,7 +116,8 @@
   :updated-at "2023-10-11T14:03:28.285983"}
  {:created-at "2023-10-13T23:14:39.974538",
   :version "23.10.13",
-  :description "Support IPFS auth, respect :forwards-to for UI smart contracts",
+  :description
+  "Support IPFS auth, respect :forwards-to for UI smart contracts",
   :libs
   ["server/district-server-smart-contracts"
    "server/district-server-bundle"
@@ -133,8 +141,7 @@
   :version "23.10.2",
   :description "improve switch chain error handling",
   :libs
-  ["browser/district-ui-web3-chain"
-   "browser/district-ui-bundle"],
+  ["browser/district-ui-web3-chain" "browser/district-ui-bundle"],
   :updated-at "2023-10-02T17:04:43.090903"}
  {:created-at "2023-09-25T08:23:14.679113",
   :version "23.9.25",


### PR DESCRIPTION
as backtrack is an optional config, this PR re-enable it. So it's up to the client of the lib to use or not depending on whether it accepts receiving duplicated events.

Also, we throw an Error if fails to fetch the block number, so we prevent getting wrong events or storing an incorrect checkpoint.